### PR TITLE
Update to use themes with white input backgrounds

### DIFF
--- a/demos/storybook/.storybook/manager-head.html
+++ b/demos/storybook/.storybook/manager-head.html
@@ -8,15 +8,6 @@
         margin: 0 8px 1rem !important;
     }
 
-    .addon-notes-container {
-        /* max-width: 1100px !important; */
-    }
-
-    /* Hide vertical divider in top bar. */
-    .css-11sh1n2 .css-ojgf1b:first-of-type {
-        display: none !important;
-    }
-
     /* This targets the selected story background color in the drawer. */
     .selected {
         background: #007bc1 !important; /* Blue[500] */
@@ -25,12 +16,5 @@
     /* This targets the href that appears in the Knobs addon when there are no knobs present. */
     .css-cz6gk6 {
         color: #007bc1 !important; /* Blue[500] */
-    }
-
-    .css-1lq66z2,
-    .css-106odw5,
-    .css-1j4ctyr,
-    .css-1ypp2lh {
-        background: white !important;
     }
 </style>

--- a/demos/storybook/package.json
+++ b/demos/storybook/package.json
@@ -10,7 +10,7 @@
         "@pxblue/icons-mui": "^2.1.0",
         "@pxblue/react-components": "^2.1.0",
         "@pxblue/react-themes": "^4.0.0",
-        "@pxblue/storybook-themes": "^1.0.2",
+        "@pxblue/storybook-themes": "^1.0.3",
         "@sambego/storybook-state": "^1.3.6",
         "@storybook/addon-actions": "^5.3.13",
         "@storybook/addon-info": "^5.3.13",

--- a/demos/storybook/yarn.lock
+++ b/demos/storybook/yarn.lock
@@ -1533,10 +1533,10 @@
     "@pxblue/colors" "^2.0.0"
     typeface-open-sans "^0.0.75"
 
-"@pxblue/storybook-themes@^1.0.2":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@pxblue/storybook-themes/-/storybook-themes-1.0.2.tgz#ba3787811c34a995293482f3a6f60ead836daf30"
-  integrity sha512-syh1dFdcKi9lfS9Kzwavn5S9njjqGVDKAyoh0x/su7+OQ25cuOWll9Ot5NqOU3K8iPA7xDpLZsmBQpUfmV6iiw==
+"@pxblue/storybook-themes@^1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@pxblue/storybook-themes/-/storybook-themes-1.0.3.tgz#4297687952ef0801443c5437d3905f4c372d3152"
+  integrity sha512-AQCQQgKa0X7HNBdfUdw7xkz+NKl5PT2D+bwG0rUPawFWFsFtlpl57SSpE6xoB61BQdEOBOiroGf8wN1r4bOj3w==
 
 "@reach/router@^1.2.1":
   version "1.2.1"


### PR DESCRIPTION
<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
Changes proposed in this Pull Request:
- Update to use latest storybook theme, which makes input field bg color white
- Remove style overrides for white input field bg color
