### PR TITLE
Don't cap max icon size

### DIFF
--- a/components/src/core/Hero/Hero.tsx
+++ b/components/src/core/Hero/Hero.tsx
@@ -53,7 +53,7 @@ const useStyles = makeStyles((theme: Theme) =>
     })
 );
 
-const normalizeIconSize = (size: number): number => Math.max(10, Math.min(72, size));
+const normalizeIconSize = (size: number): number => Math.max(10, size);
 const normalizeFontSize = (size: FontSize): string => (size === 'small' ? '1rem' : '1.25rem');
 
 type FontSize = 'normal' | 'small';

--- a/docs/Hero.md
+++ b/docs/Hero.md
@@ -39,7 +39,7 @@ import { Hero } from '@pxblue/react-components';
 | fontSize            | The text size for the value line        | `'normal'` \| `'small'`                                            | no       | 'normal'               |
 | icon                | The primary icon                        | `React.Component` \| `string`                                      | yes      |                        |
 | iconBackgroundColor | The color used behind the primary icon  | `string`                                                           | no       | 'transparent'          |
-| iconSize            | The size of the primary icon (10-72)    | `number`                                                           | no       | 36                     |
+| iconSize            | The size of the primary icon (min 10px) | `number`                                                           | no       | 36                     |
 | label               | The text shown below the `ChannelValue` | `string`                                                           | yes      |                        |
 | units               | Text to show after the value            | `string`                                                           | no       |                        |
 | value               | The value for the channel               | `string` \| `number`                                               | no       |                        |


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes #50 

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
Changes proposed in this Pull Request:
-  Don't cap max icon size at 72px