### PR TITLE
Drawer should use lighter font-weight for nested items

### DIFF
--- a/components/src/core/Drawer/DrawerNavGroup.tsx
+++ b/components/src/core/Drawer/DrawerNavGroup.tsx
@@ -242,15 +242,6 @@ function NavigationListItem(
 
     const active = activeItem === itemID;
 
-
-    const infoListClasses = {
-        title: ''
-    };
-
-    if (depth !== 0) {
-        infoListClasses.title = clsx(defaultClasses.nestedTitle, classes.nestedTitle);
-    }
-
     return (
         <div
             style={{ position: 'relative' }}
@@ -295,7 +286,7 @@ function NavigationListItem(
                 style={{ paddingLeft }}
                 hidePadding={hidePadding}
                 ripple={ripple}
-                classes={infoListClasses}
+                classes={depth > 0 ? {title: clsx(defaultClasses.nestedTitle, classes.nestedTitle)} : {}}
             />
         </div>
     );

--- a/components/src/core/Drawer/DrawerNavGroup.tsx
+++ b/components/src/core/Drawer/DrawerNavGroup.tsx
@@ -246,9 +246,9 @@ function NavigationListItem(
     const infoListClasses = {
         title: ''
     };
-    
+
     if (depth !== 0) {
-        infoListClasses.title = defaultClasses.nestedTitle + classes.nestedTitle;
+        infoListClasses.title = clsx(defaultClasses.nestedTitle, classes.nestedTitle);
     }
 
     return (

--- a/components/src/core/Drawer/DrawerNavGroup.tsx
+++ b/components/src/core/Drawer/DrawerNavGroup.tsx
@@ -83,6 +83,9 @@ const useStyles = makeStyles((theme: Theme) =>
             },
         },
         expanded: {},
+        nestedTitle: {
+            fontWeight: 400
+        },
     })
 );
 
@@ -239,6 +242,15 @@ function NavigationListItem(
 
     const active = activeItem === itemID;
 
+
+    const infoListClasses = {
+        title: ''
+    };
+    
+    if (depth !== 0) {
+        infoListClasses.title = defaultClasses.nestedTitle + classes.nestedTitle;
+    }
+
     return (
         <div
             style={{ position: 'relative' }}
@@ -283,6 +295,7 @@ function NavigationListItem(
                 style={{ paddingLeft }}
                 hidePadding={hidePadding}
                 ripple={ripple}
+                classes={infoListClasses}
             />
         </div>
     );
@@ -312,6 +325,7 @@ type DrawerNavGroupClasses = {
     listItemContainer?: string;
     nestedListGroup?: string;
     subheader?: string;
+    nestedTitle?: string;
 };
 
 export const DrawerNavGroup: React.FC<DrawerNavGroupProps> = (props) => {
@@ -405,6 +419,7 @@ DrawerNavGroup.propTypes = {
         groupHeader: PropTypes.string,
         nestedListGroup: PropTypes.string,
         subheader: PropTypes.string,
+        nestedTitle: PropTypes.string,
     }),
     drawerOpen: PropTypes.bool,
     // @ts-ignore

--- a/docs/Drawer.md
+++ b/docs/Drawer.md
@@ -173,6 +173,7 @@ You can override the classes used by PX Blue by passing a `classes` prop. The Dr
 | listItemContainer           | Styles applied to the NavItem container         |
 | nestedListGroup             | Styles applied to nested NavItems               |
 | subheader                   | Styles applied to the List subheader element    |
+| nestedTitle                 | Styles applied to nested NavItem title          |
 
 
 #### NavItem Object


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes #1172 https://jira-prod.tcc.etn.com/browse/PXBLUE-1172.

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
Changes proposed in this Pull Request:
- Set the default font-weight for nested items to 400
- Add the ability to add custom classes to style a nested items title
