### PR TITLE
Style Bug Fix on InfoListItem

### DIFF
--- a/components/src/core/InfoListItem/InfoListItem.styles.tsx
+++ b/components/src/core/InfoListItem/InfoListItem.styles.tsx
@@ -3,7 +3,7 @@ import { InfoListItemProps } from './InfoListItem';
 import color from 'color';
 import * as Colors from '@pxblue/colors';
 
-const getMinHeight = (props: InfoListItemProps): number => (props.dense ? 52 : 72);
+const getHeight = (props: InfoListItemProps): number => (props.dense ? 52 : 72);
 const getIconColor = (props: InfoListItemProps): string => {
     const { avatar, iconColor, statusColor } = props;
     if (iconColor) return iconColor;
@@ -19,14 +19,15 @@ export const useStyles = makeStyles<Theme, InfoListItemProps>((theme: Theme) =>
         root: {
             cursor: (props) => (props.onClick ? 'pointer' : 'default'),
             backgroundColor: (props) => props.backgroundColor || 'inherit',
+            height: (props) => (props.wrapSubtitle || props.wrapTitle) ? 'unset' : getHeight(props),
+            minHeight: (props) =>  (props.wrapSubtitle || props.wrapTitle) ? getHeight(props) : 'unset'
         },
         avatar: {
             backgroundColor: (props) => props.statusColor || Colors.black[500],
             color: (props) => getIconColor(props),
         },
         listItem: {
-            height: (props) => (props.wrapSubtitle || props.wrapTitle ? 'unset' : getMinHeight(props)),
-            minHeight: (props) => getMinHeight(props),
+            height: '100%',
             '&:hover': {
                 backgroundColor: (props) => (props.onClick ? 'rgba(0, 0, 0, .08)' : ''),
             },

--- a/components/src/core/InfoListItem/InfoListItem.tsx
+++ b/components/src/core/InfoListItem/InfoListItem.tsx
@@ -118,13 +118,13 @@ export const InfoListItem: React.FC<InfoListItemProps> = (props) => {
     };
 
     return (
-        <div className={combine('root')}>
+        <div className={combine('root')}
+             style={style}>
             <ListItem
                 button={ripple ? true : undefined}
                 className={combine('listItem')}
                 dense={dense}
                 onClick={onClick ? (): void => onClick() : undefined}
-                style={style}
             >
                 <div className={defaultClasses.statusStripe} />
                 {divider && <Divider className={defaultClasses.divider} />}


### PR DESCRIPTION
<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
Changes proposed in this Pull Request:
- Apply InfoListItem style prop to root element.
- Move more styles to the root class.

Scorecard Storybook with InfoListItems was looking larger than usual because styles were not being applied to root element as expected. 