### PR TITLE
Add fix to Drawer to only set a margin on Content for non-temporary D…

### DIFF
--- a/components/src/core/Drawer/Drawer.tsx
+++ b/components/src/core/Drawer/Drawer.tsx
@@ -224,7 +224,7 @@ export const DrawerComponent: React.FC<DrawerComponentProps> = (props) => {
     useEffect(() => {
         const content = document.getElementById('@@pxb-drawerlayout-content');
         if (content) {
-            content.style.marginLeft = `${containerWidth}px`;
+            content.style.marginLeft = variant === 'temporary' ? '0px' : `${containerWidth}px`;
         }
     }, [containerWidth]);
 

--- a/components/src/core/Drawer/Drawer.tsx
+++ b/components/src/core/Drawer/Drawer.tsx
@@ -223,8 +223,6 @@ export const DrawerComponent: React.FC<DrawerComponentProps> = (props) => {
 
     useEffect(() => {
         const content = document.getElementById('@@pxb-drawerlayout-content');
-        console.log(variant);
-        console.log(containerWidth);
         if (content) {
             content.style.marginLeft = variant === 'temporary' ? '0px' : `${containerWidth}px`;
         }

--- a/components/src/core/Drawer/Drawer.tsx
+++ b/components/src/core/Drawer/Drawer.tsx
@@ -223,10 +223,12 @@ export const DrawerComponent: React.FC<DrawerComponentProps> = (props) => {
 
     useEffect(() => {
         const content = document.getElementById('@@pxb-drawerlayout-content');
+        console.log(variant);
+        console.log(containerWidth);
         if (content) {
             content.style.marginLeft = variant === 'temporary' ? '0px' : `${containerWidth}px`;
         }
-    }, [containerWidth]);
+    }, [containerWidth, variant]);
 
     return (
         <Drawer

--- a/components/src/core/DrawerLayout/DrawerLayout.tsx
+++ b/components/src/core/DrawerLayout/DrawerLayout.tsx
@@ -14,7 +14,6 @@ const useStyles = makeStyles((theme: Theme) =>
     createStyles({
         root: {
             display: 'flex',
-            height: '100%',
             width: '100%',
         },
         drawer: {
@@ -25,7 +24,6 @@ const useStyles = makeStyles((theme: Theme) =>
         },
         content: {
             width: '100%',
-            height: '100%',
             transition: 'margin 175ms cubic-bezier(.4, 0, .2, 1)',
             [theme.breakpoints.down('xs')]: {
                 marginLeft: '0!important',

--- a/demos/showcase/src/App.js
+++ b/demos/showcase/src/App.js
@@ -28,7 +28,7 @@ export const App = () => {
     const theme = useTheme();
 
     return (
-        <div style={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
+        <div style={{  display: 'flex', flexDirection: 'column' }}>
             <div style={{ padding: theme.spacing(), flex: 1 }}>
                 <div style={{ display: 'flex', flexWrap: 'wrap' }}>
                     <ScoreCard


### PR DESCRIPTION
Changes proposed in this Pull Request:
- DrawerLayouts that have a Temporary Drawer should not have a marginLeft applied to its content.
- Remove height from DrawerLayout content container so Sticky AppBar doesn't disappear on scroll down.