### PR TITLE
Nested NavItem Hover Style Fix

### DIFF
--- a/components/src/core/Drawer/DrawerNavItem.tsx
+++ b/components/src/core/Drawer/DrawerNavItem.tsx
@@ -44,12 +44,18 @@ export type DrawerNavItem = {
     expandHandler?: Function;
 };
 
+// First nested item has no additional indentation.  All items start with 16px indentation.
+const calcNestedPadding = (theme: Theme, depth: number): number => theme.spacing(depth ? (depth-1) * 4 : 0) + theme.spacing(2);
+
 const useStyles = makeStyles((theme: Theme) =>
     createStyles({
         listItemNoHover: {
             '&:hover': {
                 backgroundColor: 'unset',
             },
+        },
+        infoListItem: {
+            paddingLeft: (props: DrawerNavItem): number => calcNestedPadding(theme, props.depth)
         },
         active: {
             content: '""',
@@ -97,7 +103,7 @@ export const DrawerNavItem: React.FC<DrawerNavItem> = (props) => {
     // only allow icons for the top level items
     const icon = !depth ? (navItem as NavItem).icon : undefined;
 
-    const defaultClasses = useStyles(navGroupProps);
+    const defaultClasses = useStyles(props);
     const theme = useTheme();
     // @ts-ignore
     const primary50Color = theme.palette.primary[50];
@@ -180,12 +186,11 @@ export const DrawerNavItem: React.FC<DrawerNavItem> = (props) => {
     }
 
     const actionComponent = getActionComponent();
-
-    // 0 indents for top level nav items
-    // 0, 2, 4, ... for secondary level and beyond
-    const paddingLeft = theme.spacing(depth ? (depth - 1) * 4 : 0);
-
     const active = activeItem === itemID;
+    const infoListItemClasses = {
+        listItem: defaultClasses.infoListItem,
+        title: (depth > 0) ? clsx(defaultClasses.nestedTitle, classes.nestedTitle) : ''
+    };
 
     return (
         <div
@@ -219,18 +224,10 @@ export const DrawerNavItem: React.FC<DrawerNavItem> = (props) => {
                 }
                 backgroundColor={'transparent'}
                 onClick={hasAction ? onClickAction : undefined}
-                style={{ paddingLeft }}
                 hidePadding={hidePadding}
                 ripple={ripple}
                 {...InfoListItemProps}
-                classes={
-                    depth > 0
-                        ? Object.assign(
-                              { title: clsx(defaultClasses.nestedTitle, classes.nestedTitle) },
-                              InfoListItemProps.classes
-                          )
-                        : InfoListItemProps.classes
-                }
+                classes={Object.assign(infoListItemClasses, InfoListItemProps.classes)}
             />
         </div>
     );

--- a/docs/Drawer.md
+++ b/docs/Drawer.md
@@ -178,6 +178,58 @@ You can override the classes used by PX Blue by passing a `classes` prop. The `D
 | nestedTitle                 | Styles applied to nested NavItem title          |
 
 
+## DrawerFooter
+The `DrawerFooter` is an optional section that renders at the bottom of the `Drawer`. It can be used to add any custom content (as children).
+
+### Usage
+```typescript
+import DrawerFooter from '@pxblue/react-components/core/Drawer';
+...
+<DrawerFooter>
+    <div>Custom Footer goes here</div>
+</DrawerFooter>
+```
+
+### DrawerFooter API
+
+<div style="overflow: auto;">
+
+| Prop Name       | Description                       | Type          | Required | Default |
+|-----------------|-----------------------------------|---------------|----------|---------|
+| backgroundColor | The color used for the background | `string`      | no       |         |   
+
+</div>
+
+## Shared Props
+The following props can be set at any level in the drawer hierarchy (`Drawer`, `DrawerBody`, `DrawerNavGroup`, `NavItem`, or `NestedNavItem`). If they are set on a parent, they will be used for all children. For more customization, you can set these props on individual children and they will override any value set on the parent.
+
+| Name                      | Description                                                | Type               | Required | Default                                                    |
+| ------------------------- | ---------------------------------------------------------- | ------------------ | -------- | ---------------------------------------------------------- |
+| activeItemBackgroundColor | Background color for the 'active' item                     | `string`           | no       | varies for light/dark theme                                |
+| activeItemBackgroundShape | shape of the active item background                        | `'round'|'square'` | no       | round                                                      |
+| activeItemFontColor       | Font color for the 'active' item                           | `string`           | no       | varies for light/dark theme                                |
+| activeItemIconColor       | Icon color for the 'active' item                           | `string`           | no       | varies for light/dark theme                                |
+| chevron                   | Whether to have chevrons for all menu items                | `boolean`          | no       |                                                            |
+| collapseIcon              | Icon used to collapse drawer                               | `JSX.Element`      | no       | `expandIcon` rotated 180 degrees                           |
+| divider                   | Whether to show a line between all items                   | `boolean`          | no       | true                                                       |
+| expandIcon                | Icon used to expand drawer                                 | `JSX.Element`      | no       | `<ExpandLess />` at top-level, `<ArrowDropUp />` otherwise |
+| hidePadding               | Whether to hide the paddings reserved for menu item icons  | `boolean`          | no       |                                                            |
+| InfoListItemProps         | Used to override InfoListItem props set by the Drawer      | `InfoListItemProps`| no       |                                                            |
+| itemFontColor             | The color used for the item text                           | `string`           | no       | gray[500]                                                  |
+| itemIconColor             | The color used for the icon                                | `string`           | no       | gray[500]                                                  |
+| ripple                    | Whether to apply material ripple effect to items           | `boolean`          | no       | true                                                       |
+
+The following props control the NavGroup and thus only apply to `Drawer`, and `DrawerNavGroupProps` (so not `NavItem` or `NestedNavItem`):
+
+| Name                  | Description                                      | Type      | Required | Default                                                      |
+| --------------------- | ------------------------------------------------ | --------- | -------- | ------------------------------------------------------------ |
+| activeItem            | itemID for the 'active' item                     | `string`  | no       |                                                              |
+| nestedBackgroundColor | background color for nested menu items           | `string`  | no       | theme.palette.type === 'light' ? white[200] : black['A200'], |
+| nestedDivider         | Whether to show a line between nested menu items | `boolean` | no       | false                                                        |
+| titleColor            | Font color for group header                      | `string`  | no       | theme.palette.text.primary                                   |
+
+## DrawerNavItem
+
 #### NavItem Object
 The `items` prop of the `DrawerNavGroup` takes a list of items with the following structure (most of these properties are inherited from `<InfoListItem/>`). A `NavItem` can also include a list of `NestedNavItem` to create a tree structure (see below).
 
@@ -235,54 +287,7 @@ The `items` property of the NavItem can be nested to create a tree structure wit
 />
 ```
 
-## DrawerFooter
-The `DrawerFooter` is an optional section that renders at the bottom of the `Drawer`. It can be used to add any custom content (as children).
 
-### Usage
-```typescript
-import DrawerFooter from '@pxblue/react-components/core/Drawer';
-...
-<DrawerFooter>
-    <div>Custom Footer goes here</div>
-</DrawerFooter>
-```
-
-### DrawerFooter API
-
-<div style="overflow: auto;">
-
-| Prop Name       | Description                       | Type          | Required | Default |
-|-----------------|-----------------------------------|---------------|----------|---------|
-| backgroundColor | The color used for the background | `string`      | no       |         |   
-
-</div>
-
-## Shared Props
-The following props can be set at any level in the drawer hierarchy (`Drawer`, `DrawerNavGroup`, `NavItem`, or `NestedNavItem`). If they are set on a parent, they will be used for all children. For more customization, you can set these props on individual children and they will override any value set on the parent.
-
-| Name                      | Description                                                | Type               | Required | Default                                                    |
-| ------------------------- | ---------------------------------------------------------- | ------------------ | -------- | ---------------------------------------------------------- |
-| activeItemBackgroundColor | Background color for the 'active' item                     | `string`           | no       | varies for light/dark theme                                |
-| activeItemBackgroundShape | shape of the active item background                        | `'round'|'square'` | no       | round                                                      |
-| activeItemFontColor       | Font color for the 'active' item                           | `string`           | no       | varies for light/dark theme                                |
-| activeItemIconColor       | Icon color for the 'active' item                           | `string`           | no       | varies for light/dark theme                                |
-| chevron                   | Whether to have chevrons for all menu items                | `boolean`          | no       |                                                            |
-| collapseIcon              | Icon used to collapse drawer                               | `JSX.Element`      | no       | `expandIcon` rotated 180 degrees                           |
-| divider                   | Whether to show a line between all items                   | `boolean`          | no       | true                                                       |
-| expandIcon                | Icon used to expand drawer                                 | `JSX.Element`      | no       | `<ExpandLess />` at top-level, `<ArrowDropUp />` otherwise |
-| hidePadding               | Whether to hide the paddings reserved for menu item icons  | `boolean`          | no       |                                                            |
-| itemFontColor             | The color used for the item text                           | `string`           | no       | gray[500]                                                  |
-| itemIconColor             | The color used for the icon                                | `string`           | no       | gray[500]                                                  |
-| ripple                    | Whether to apply material ripple effect to items           | `boolean`          | no       | true                                                       |
-
-The following props control the NavGroup and thus only apply to `Drawer`, and `DrawerNavGroupProps` (so not `NavItem` or `NestedNavItem`):
-
-| Name                  | Description                                      | Type      | Required | Default                                                      |
-| --------------------- | ------------------------------------------------ | --------- | -------- | ------------------------------------------------------------ |
-| activeItem            | itemID for the 'active' item                     | `string`  | no       |                                                              |
-| nestedBackgroundColor | background color for nested menu items           | `string`  | no       | theme.palette.type === 'light' ? white[200] : black['A200'], |
-| nestedDivider         | Whether to show a line between nested menu items | `boolean` | no       | false                                                        |
-| titleColor            | Font color for group header                      | `string`  | no       | theme.palette.text.primary                                   |
 
 # DrawerLayout
 The `DrawerLayout` component is used to provide the appropriate resizing behavior for your main application content when used in conjunction with  a PX Blue `Drawer`. It accepts a `Drawer` as a prop, and the main page content is passed in through child elements.

--- a/docs/Drawer.md
+++ b/docs/Drawer.md
@@ -134,11 +134,12 @@ import DrawerBody from '@pxblue/react-components/core/Drawer';
 | Prop Name               | Description                                    | Type          | Required | Default |
 |-------------------------|------------------------------------------------|---------------|----------|---------|
 | backgroundColor         | The color used for the background              | `string`      | no       |         |
+| classes                 | Style overrides                                | `StyleRules`  | no       |         |
 
 </div>
 
 #### Classes
-You can override the classes used by PX Blue by passing a `classes` prop. The DrawerBody supports the following keys:
+You can override the classes used by PX Blue by passing a `classes` prop. The `DrawerBody` supports the following keys:
 
 | Name             | Description                                     |
 |------------------|-------------------------------------------------|
@@ -156,6 +157,7 @@ The `items` property supports nested items to generate collapsible sections in t
 | Prop Name                       | Description                                                | Type              | Required | Default |
 |---------------------------------|------------------------------------------------------------|-------------------|----------|---------|
 | backgroundColor                 | The color used for the background                          | `string`          | no       |         | 
+| classes                         | Style overrides                                            | `StyleRules`      | no       |         |
 | items                           | List of NavItems to render                                 | `NestedNavItem[]` | yes      |         | 
 | title                           | Text to display in the group header                        | `string`          | no       |         |  
 | titleContent                    | Custom element, substitute for title                       | `React.Component` | no       |         | 
@@ -163,7 +165,7 @@ The `items` property supports nested items to generate collapsible sections in t
 
 
 #### Classes
-You can override the classes used by PX Blue by passing a `classes` prop. The DrawerNavGroup supports the following keys:
+You can override the classes used by PX Blue by passing a `classes` prop. The `DrawerNavGroup` supports the following keys:
 
 | Name                        | Description                                     |
 |-----------------------------|-------------------------------------------------|
@@ -177,7 +179,7 @@ You can override the classes used by PX Blue by passing a `classes` prop. The Dr
 
 
 #### NavItem Object
-The `items` prop of the `DrawerNavGroup` takes a list of items with the following structure (most of these properties are inherited from `<InfoListItem/>`). NavItem can also include a list of `NestedNavItem` to create a tree structure (see below).
+The `items` prop of the `DrawerNavGroup` takes a list of items with the following structure (most of these properties are inherited from `<InfoListItem/>`). A `NavItem` can also include a list of `NestedNavItem` to create a tree structure (see below).
 
 <div style="overflow: auto;">
 

--- a/docs/Drawer.md
+++ b/docs/Drawer.md
@@ -200,34 +200,6 @@ import DrawerFooter from '@pxblue/react-components/core/Drawer';
 
 </div>
 
-## Shared Props
-The following props can be set at any level in the drawer hierarchy (`Drawer`, `DrawerBody`, `DrawerNavGroup`, `NavItem`, or `NestedNavItem`). If they are set on a parent, they will be used for all children. For more customization, you can set these props on individual children and they will override any value set on the parent.
-
-| Name                      | Description                                                | Type               | Required | Default                                                    |
-| ------------------------- | ---------------------------------------------------------- | ------------------ | -------- | ---------------------------------------------------------- |
-| activeItemBackgroundColor | Background color for the 'active' item                     | `string`           | no       | varies for light/dark theme                                |
-| activeItemBackgroundShape | shape of the active item background                        | `'round'|'square'` | no       | round                                                      |
-| activeItemFontColor       | Font color for the 'active' item                           | `string`           | no       | varies for light/dark theme                                |
-| activeItemIconColor       | Icon color for the 'active' item                           | `string`           | no       | varies for light/dark theme                                |
-| chevron                   | Whether to have chevrons for all menu items                | `boolean`          | no       |                                                            |
-| collapseIcon              | Icon used to collapse drawer                               | `JSX.Element`      | no       | `expandIcon` rotated 180 degrees                           |
-| divider                   | Whether to show a line between all items                   | `boolean`          | no       | true                                                       |
-| expandIcon                | Icon used to expand drawer                                 | `JSX.Element`      | no       | `<ExpandLess />` at top-level, `<ArrowDropUp />` otherwise |
-| hidePadding               | Whether to hide the paddings reserved for menu item icons  | `boolean`          | no       |                                                            |
-| InfoListItemProps         | Used to override InfoListItem props set by the Drawer      | `InfoListItemProps`| no       |                                                            |
-| itemFontColor             | The color used for the item text                           | `string`           | no       | gray[500]                                                  |
-| itemIconColor             | The color used for the icon                                | `string`           | no       | gray[500]                                                  |
-| ripple                    | Whether to apply material ripple effect to items           | `boolean`          | no       | true                                                       |
-
-The following props control the NavGroup and thus only apply to `Drawer`, and `DrawerNavGroupProps` (so not `NavItem` or `NestedNavItem`):
-
-| Name                  | Description                                      | Type      | Required | Default                                                      |
-| --------------------- | ------------------------------------------------ | --------- | -------- | ------------------------------------------------------------ |
-| activeItem            | itemID for the 'active' item                     | `string`  | no       |                                                              |
-| nestedBackgroundColor | background color for nested menu items           | `string`  | no       | theme.palette.type === 'light' ? white[200] : black['A200'], |
-| nestedDivider         | Whether to show a line between nested menu items | `boolean` | no       | false                                                        |
-| titleColor            | Font color for group header                      | `string`  | no       | theme.palette.text.primary                                   |
-
 ## DrawerNavItem
 
 #### NavItem Object
@@ -286,6 +258,35 @@ The `items` property of the NavItem can be nested to create a tree structure wit
     ]
 />
 ```
+
+
+## Shared Props
+The following props can be set at any level in the drawer hierarchy (`Drawer`, `DrawerBody`, `DrawerNavGroup`, `NavItem`, or `NestedNavItem`). If they are set on a parent, they will be used for all children. For more customization, you can set these props on individual children and they will override any value set on the parent.
+
+| Name                      | Description                                                | Type               | Required | Default                                                    |
+| ------------------------- | ---------------------------------------------------------- | ------------------ | -------- | ---------------------------------------------------------- |
+| activeItemBackgroundColor | Background color for the 'active' item                     | `string`           | no       | varies for light/dark theme                                |
+| activeItemBackgroundShape | shape of the active item background                        | `'round'|'square'` | no       | round                                                      |
+| activeItemFontColor       | Font color for the 'active' item                           | `string`           | no       | varies for light/dark theme                                |
+| activeItemIconColor       | Icon color for the 'active' item                           | `string`           | no       | varies for light/dark theme                                |
+| chevron                   | Whether to have chevrons for all menu items                | `boolean`          | no       |                                                            |
+| collapseIcon              | Icon used to collapse drawer                               | `JSX.Element`      | no       | `expandIcon` rotated 180 degrees                           |
+| divider                   | Whether to show a line between all items                   | `boolean`          | no       | true                                                       |
+| expandIcon                | Icon used to expand drawer                                 | `JSX.Element`      | no       | `<ExpandLess />` at top-level, `<ArrowDropUp />` otherwise |
+| hidePadding               | Whether to hide the paddings reserved for menu item icons  | `boolean`          | no       |                                                            |
+| InfoListItemProps         | Used to override InfoListItem props set by the Drawer      | `InfoListItemProps`| no       |                                                            |
+| itemFontColor             | The color used for the item text                           | `string`           | no       | gray[500]                                                  |
+| itemIconColor             | The color used for the icon                                | `string`           | no       | gray[500]                                                  |
+| ripple                    | Whether to apply material ripple effect to items           | `boolean`          | no       | true                                                       |
+
+The following props control the NavGroup and thus only apply to `Drawer`, and `DrawerNavGroupProps` (so not `NavItem` or `NestedNavItem`):
+
+| Name                  | Description                                      | Type      | Required | Default                                                      |
+| --------------------- | ------------------------------------------------ | --------- | -------- | ------------------------------------------------------------ |
+| activeItem            | itemID for the 'active' item                     | `string`  | no       |                                                              |
+| nestedBackgroundColor | background color for nested menu items           | `string`  | no       | theme.palette.type === 'light' ? white[200] : black['A200'], |
+| nestedDivider         | Whether to show a line between nested menu items | `boolean` | no       | false                                                        |
+| titleColor            | Font color for group header                      | `string`  | no       | theme.palette.text.primary                                   |
 
 
 


### PR DESCRIPTION
<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
Changes proposed in this Pull Request:
-  Fix the nested drawer NavItem hover effect by moving the paddingLeft style from InfoListItem `root` class to the `infoListItem` class. 
