### PR TITLE
Allow click without expand

### DIFF
--- a/components/src/core/Drawer/DrawerNavItem.tsx
+++ b/components/src/core/Drawer/DrawerNavItem.tsx
@@ -152,7 +152,7 @@ export const DrawerNavItem: React.FC<DrawerNavItem> = (props) => {
         if (onClick) {
             onClick();
         }
-        if (expandHandler) {
+        else if (expandHandler) {
             expandHandler();
         }
     };


### PR DESCRIPTION
<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
Changes proposed in this Pull Request:
- If a NavItem has a click event, don't auto-collapse/expand when the item is clicked
- Items can still be expanded by clicking the expand icon
