### PR TITLE
Allow InfolistItem title to take elements or string

### DIFF
--- a/components/src/core/InfoListItem/InfoListItem.tsx
+++ b/components/src/core/InfoListItem/InfoListItem.tsx
@@ -42,7 +42,7 @@ export type InfoListItemProps = {
     style?: CSSProperties;
     subtitle?: string | Array<string | JSX.Element>;
     subtitleSeparator?: string;
-    title: string;
+    title: React.ReactNode;
     wrapSubtitle?: boolean;
     wrapTitle?: boolean;
 };

--- a/docs/InfoListItem.md
+++ b/docs/InfoListItem.md
@@ -41,7 +41,7 @@ import * as Colors from '@pxblue/colors';
 | statusColor       | Status stripe and icon color                     | `string`                                           | no       |                     |
 | subtitle          | The text to show on the second line              | `string` \| `Array<React.ReactNode>`               | no       |                     |
 | subtitleSeparator | Separator character for subtitle                 | `string`                                           | no       | '·' ('\u00B7')      |
-| title             | The text to show on the first line               | `string`                                           | yes      |                     |
+| title             | The text to show on the first line               | `React.ReactNode`                                  | yes      |                     |
 | wrapSubtitle      | Whether to wrap subtitle on overflow             | `boolean`                                          | no       | true                |
 | wrapTitle         | Whether to wrap title on overflow                | `boolean`                                          | no       | true                |
 


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Allows you to pass in any renderable content to InfoListItem title. This is requested by the Seed UI team, and is also needed for the doc-site to avoid some ugly hacky workarounds.

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
Changes proposed in this Pull Request:
- Update prop type to React.ReactNode instead of string
