### PR TITLE
Fix a missing icon in drawer full config story

### DIFF
--- a/demos/storybook/stories/drawer/with-full-config.tsx
+++ b/demos/storybook/stories/drawer/with-full-config.tsx
@@ -4,6 +4,7 @@ import {
     Add,
     AddAPhoto,
     AirportShuttle,
+    Dashboard,
     Devices,
     FitnessCenter,
     NotificationsActive,
@@ -66,6 +67,8 @@ const getIcon = (icon: string): JSX.Element | undefined => {
             return <Menu />;
         case '<FitnessCenter />':
             return <FitnessCenter />;
+        case '<Dashboard />':
+            return <Dashboard />;
         case 'undefined':
         default:
             return undefined;


### PR DESCRIPTION
Changes proposed in this Pull Request:
- `<Dashboard />` icon was missing in the drawer full config story
