### PR TITLE
Enable scorecard to extend all card props

### DIFF
--- a/components/src/core/DrawerLayout/DrawerLayout.tsx
+++ b/components/src/core/DrawerLayout/DrawerLayout.tsx
@@ -3,9 +3,6 @@ import { createStyles, makeStyles, Theme, useTheme } from '@material-ui/core/sty
 import PropTypes from 'prop-types';
 
 export type DrawerLayoutProps = {
-    // Page's body
-    children: React.ReactNode;
-
     // Drawer component to be embedded
     drawer: React.ReactNode;
 };
@@ -47,6 +44,5 @@ export const DrawerLayout: React.FC<DrawerLayoutProps> = (props) => {
 
 DrawerLayout.displayName = 'DrawerLayout';
 DrawerLayout.propTypes = {
-    children: PropTypes.element.isRequired,
     drawer: PropTypes.element.isRequired,
 };

--- a/components/src/core/Hero/Hero.tsx
+++ b/components/src/core/Hero/Hero.tsx
@@ -85,7 +85,7 @@ export const Hero = (props: HeroProps): JSX.Element => {
 
     return (
         <div
-            style={{ cursor: onClick ? 'pointer' : 'default' }}
+            style={{ cursor: onClick ? 'pointer' : 'inherit' }}
             className={clsx(defaultClasses.root, classes.root)}
             onClick={onClick ? (): void => onClick() : undefined}
             data-test={'wrapper'}

--- a/components/src/core/InfoListItem/InfoListItem.styles.tsx
+++ b/components/src/core/InfoListItem/InfoListItem.styles.tsx
@@ -17,7 +17,7 @@ const getIconColor = (props: InfoListItemProps): string => {
 export const useStyles = makeStyles<Theme, InfoListItemProps>((theme: Theme) =>
     createStyles({
         root: {
-            cursor: (props) => (props.onClick ? 'pointer' : 'default'),
+            cursor: (props) => (props.onClick ? 'pointer' : 'inherit'),
             backgroundColor: (props) => props.backgroundColor || 'inherit',
             height: (props) => (props.wrapSubtitle || props.wrapTitle ? 'unset' : getHeight(props)),
             minHeight: (props) => (props.wrapSubtitle || props.wrapTitle ? getHeight(props) : 'unset'),

--- a/components/src/core/ListItemTag/ListItemTag.tsx
+++ b/components/src/core/ListItemTag/ListItemTag.tsx
@@ -44,7 +44,7 @@ export const ListItemTag: React.FC<ListItemTagProps> = (props: ListItemTagProps)
                 {
                     color: fontColor,
                     backgroundColor: backgroundColor,
-                    cursor: props.onClick ? 'pointer' : 'default',
+                    cursor: props.onClick ? 'pointer' : 'inherit',
                 },
                 style
             )}

--- a/components/src/core/ScoreCard/ScoreCard.tsx
+++ b/components/src/core/ScoreCard/ScoreCard.tsx
@@ -1,6 +1,5 @@
-import { CSSProperties } from '@material-ui/styles';
 import React from 'react';
-import { Card, Typography, Divider, Theme, makeStyles, createStyles } from '@material-ui/core';
+import { Card, Typography, Divider, Theme, makeStyles, createStyles, CardProps } from '@material-ui/core';
 import * as Colors from '@pxblue/colors';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
@@ -81,7 +80,7 @@ type ScoreCardClasses = {
     headerSubtitle?: string;
 };
 
-export type ScoreCordProps = {
+export type ScoreCordProps = CardProps & {
     actionItems?: JSX.Element[];
     actionLimit?: number;
     actionRow?: JSX.Element;
@@ -94,7 +93,6 @@ export type ScoreCordProps = {
     headerInfo?: string | JSX.Element;
     headerTitle: string;
     headerSubtitle?: string | JSX.Element;
-    style?: CSSProperties;
 };
 
 export const ScoreCard: React.FC<ScoreCordProps> = (props) => {
@@ -113,7 +111,7 @@ export const ScoreCard: React.FC<ScoreCordProps> = (props) => {
         headerInfo,
         headerTitle,
         headerSubtitle,
-        style,
+        ...cardProps
     } = props;
 
     const fontColor = (): string => headerFontColor || Colors.white[50];
@@ -221,7 +219,7 @@ export const ScoreCard: React.FC<ScoreCordProps> = (props) => {
     };
 
     return (
-        <Card className={clsx(defaultClasses.root, classes.root)} style={style} data-test={'card'}>
+        <Card className={clsx(defaultClasses.root, classes.root)} data-test={'card'} {...cardProps}>
             <div
                 data-test={'header'}
                 className={clsx(defaultClasses.header, classes.header)}
@@ -270,7 +268,6 @@ ScoreCard.propTypes = {
     headerInfo: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
     headerTitle: PropTypes.string.isRequired,
     headerSubtitle: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
-    style: PropTypes.objectOf(PropTypes.oneOfType([PropTypes.string, PropTypes.number])),
 };
 ScoreCard.defaultProps = {
     actionLimit: 3,

--- a/docs/Drawer.md
+++ b/docs/Drawer.md
@@ -314,7 +314,6 @@ import { Drawer, DrawerLayout } from '@pxblue/react-components';
 
 | Prop Name          | Description                     | Type              | Required | Default |
 |--------------------|---------------------------------|-------------------|----------|---------|
-| children           | Page's body content             | `React.ReactNode` | yes      |         |   
 | drawer             | Drawer component to be embedded | `React.ReactNode` | yes      |         |    
 
 </div>

--- a/docs/ScoreCard.md
+++ b/docs/ScoreCard.md
@@ -73,6 +73,8 @@ import { Temp } from '@pxblue/icons-mui';
 
 </div>
 
+The `ScoreCard` also extends all Material UI Card props.
+
 
 ### Classes
 You can override the classes used by PX Blue by passing a `classes` prop. It supports the following keys:


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
For upcoming feature in WAS (need entire card clickable).

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
Changes proposed in this Pull Request:
- Spread all MUI Card props to the underlying card component in ScoreCard
- Update non-pointer cursors to 'inherit' instead of 'default'
- Allow multiple children in DrawerLayout
