### PR TITLE
If not wrapping text, enforce height at 52 or 72 px

### DIFF
--- a/components/src/core/InfoListItem/InfoListItem.styles.tsx
+++ b/components/src/core/InfoListItem/InfoListItem.styles.tsx
@@ -13,13 +13,16 @@ const getIconColor = (props: InfoListItemProps): string => {
     return statusColor ? statusColor : 'inherit';
 };
 
+const isWrapEnabled = (props: InfoListItemProps): boolean => (props.wrapSubtitle || props.wrapTitle);
+
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
 export const useStyles = makeStyles<Theme, InfoListItemProps>((theme: Theme) =>
     createStyles({
         root: {
             cursor: (props) => (props.onClick ? 'pointer' : 'inherit'),
             backgroundColor: (props) => props.backgroundColor || 'inherit',
-            minHeight: (props) => getHeight(props),
+            minHeight: (props) => (isWrapEnabled(props)) ? getHeight(props) : 'unset',
+            height: (props) => (!isWrapEnabled(props)) ? getHeight(props) : 'auto',
             '&:hover': {
                 backgroundColor: (props) =>
                     props.onClick


### PR DESCRIPTION
<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
Changes proposed in this Pull Request:
- Dense prop on InfoListItem not applying 52px height when checked due to minHeight being set instead of height.
- Only set minHeight when wrapping title or subtitle.
