### PR TITLE
Fix logic around navItem rightComponent

### DIFF
--- a/components/src/core/Drawer/Drawer.test.tsx
+++ b/components/src/core/Drawer/Drawer.test.tsx
@@ -14,6 +14,7 @@ import { DrawerBody } from './DrawerBody';
 import { DrawerFooter } from './DrawerFooter';
 import { DrawerNavGroup } from './DrawerNavGroup';
 import { InfoListItem } from '../InfoListItem';
+import { MoreVert } from '@material-ui/icons';
 
 Enzyme.configure({ adapter: new Adapter() });
 
@@ -97,6 +98,14 @@ describe('DrawerNavGroup', () => {
     it('renders custom content correctly', () => {
         const wrapper = mount(<DrawerNavGroup titleContent={<Avatar />} items={[]} />);
         expect(wrapper.find(Avatar).length).toEqual(1);
+    });
+
+    it('renders rightComponent correctly', () => {
+        let wrapper = mount(<DrawerNavGroup items={[{ title: '', itemID: '', rightComponent: <MoreVert /> }]} />);
+        expect(wrapper.find(MoreVert).length).toEqual(1);
+
+        wrapper = mount(<DrawerNavGroup items={[{ title: '', itemID: '' }]} />);
+        expect(wrapper.find(MoreVert).length).toEqual(0);
     });
 
     it('renders its menu items recursively in the correct order', () => {

--- a/components/src/core/Drawer/DrawerNavItem.tsx
+++ b/components/src/core/Drawer/DrawerNavItem.tsx
@@ -163,7 +163,7 @@ export const DrawerNavItem: React.FC<DrawerNavItem> = (props) => {
         }
     };
 
-    const rightComponent = navItem.rightComponent || (chevron && !items) ? <ChevronRight /> : undefined;
+    const rightComponent = navItem.rightComponent || (chevron && !items ? <ChevronRight /> : undefined);
 
     function getActionComponent(): JSX.Element {
         if (!items) {


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes issue where rightComponent is always rendering as chevron in NavItem .

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
Changes proposed in this Pull Request:
- Fix parenthesis logic 
- Add unit test to protect this feature in the future
