### PR TITLE
Release 3.0.2 patch

### DIFF
--- a/components/package.json
+++ b/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pxblue/react-components",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "React components for PX Blue applications",
   "scripts": {
     "test": "jest src",

--- a/components/package.json
+++ b/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pxblue/react-components",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "React components for PX Blue applications",
   "scripts": {
     "test": "jest src",

--- a/components/src/core/Drawer/DrawerNavItem.tsx
+++ b/components/src/core/Drawer/DrawerNavItem.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { createStyles, makeStyles, Theme, useTheme } from '@material-ui/core/styles';
-import { ArrowDropDown, ChevronRight, ExpandMore } from '@material-ui/icons';
+import ArrowDropDown from '@material-ui/icons/ArrowDropDown';
+import ChevronRight from '@material-ui/icons/ChevronRight';
+import ExpandMore from '@material-ui/icons/ExpandMore';
 import { gray } from '@pxblue/colors';
 import clsx from 'clsx';
 import { PXBlueDrawerInheritableProperties } from './Drawer';

--- a/components/src/core/InfoListItem/InfoListItem.styles.tsx
+++ b/components/src/core/InfoListItem/InfoListItem.styles.tsx
@@ -13,7 +13,7 @@ const getIconColor = (props: InfoListItemProps): string => {
     return statusColor ? statusColor : 'inherit';
 };
 
-const isWrapEnabled = (props: InfoListItemProps): boolean => (props.wrapSubtitle || props.wrapTitle);
+const isWrapEnabled = (props: InfoListItemProps): boolean => props.wrapSubtitle || props.wrapTitle;
 
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
 export const useStyles = makeStyles<Theme, InfoListItemProps>((theme: Theme) =>
@@ -21,8 +21,8 @@ export const useStyles = makeStyles<Theme, InfoListItemProps>((theme: Theme) =>
         root: {
             cursor: (props) => (props.onClick ? 'pointer' : 'inherit'),
             backgroundColor: (props) => props.backgroundColor || 'inherit',
-            minHeight: (props) => (isWrapEnabled(props)) ? getHeight(props) : 'unset',
-            height: (props) => (!isWrapEnabled(props)) ? getHeight(props) : 'auto',
+            minHeight: (props) => (isWrapEnabled(props) ? getHeight(props) : 'unset'),
+            height: (props) => (!isWrapEnabled(props) ? getHeight(props) : 'auto'),
             '&:hover': {
                 backgroundColor: (props) =>
                     props.onClick


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes issue where all Material icons are included in the bundle even when only a few are used.

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
Changes proposed in this Pull Request:
- Change icon import syntax from index to nested
- Fix logic for infoListItem height (3.0.1)
