### PR TITLE
Fix IE11 issues with persistent drawer (master)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Change Log
+## v3.0.3
+- Fixes IE 11 issue where persistent Drawer will not close
+- Fixes some spacing issues when using the DrawerLayout
 
 ## v3.0.0
 - Adds support for nested items in the Drawer component; 

--- a/components/package.json
+++ b/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pxblue/react-components",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "React components for PX Blue applications",
   "scripts": {
     "test": "jest src",

--- a/components/src/core/Drawer/Drawer.tsx
+++ b/components/src/core/Drawer/Drawer.tsx
@@ -9,7 +9,7 @@ import { InfoListItemProps as BaseInfoListItemProps } from '../InfoListItem';
 const useStyles = makeStyles({
     paper: {
         overflow: 'hidden',
-        position: 'unset',
+        position: 'inherit',
     },
     content: {
         display: 'flex',
@@ -224,7 +224,7 @@ export const DrawerComponent: React.FC<DrawerComponentProps> = (props) => {
     useEffect(() => {
         const content = document.getElementById('@@pxb-drawerlayout-content');
         if (content) {
-            content.style.marginLeft = variant === 'temporary' ? '0px' : `${containerWidth}px`;
+            content.style.paddingLeft = variant === 'temporary' ? '0px' : `${containerWidth}px`;
         }
     }, [containerWidth, variant]);
 

--- a/components/src/core/Drawer/DrawerNavGroup.tsx
+++ b/components/src/core/Drawer/DrawerNavGroup.tsx
@@ -153,7 +153,7 @@ export const DrawerNavGroup: React.FC<DrawerNavGroupProps> = (props) => {
                 <ListSubheader
                     className={clsx(defaultClasses.subheader, classes.subheader)}
                     style={{
-                        position: 'unset',
+                        position: 'inherit',
                         color: open ? titleColor : 'transparent',
                     }}
                 >

--- a/components/src/core/Drawer/DrawerNavItem.tsx
+++ b/components/src/core/Drawer/DrawerNavItem.tsx
@@ -54,7 +54,12 @@ const useStyles = makeStyles((theme: Theme) =>
     createStyles({
         listItemNoHover: {
             '&:hover': {
-                backgroundColor: 'unset',
+                /* TODO: 
+                 * I don't believe this style is actually doing anything. The original intent was to not show
+                 * the background on hover over the active item, but this hover state is now controlled in the
+                 * InfoListItem component and is based on the presence of a onClick property.
+                */
+                backgroundColor: 'initial',
             },
         },
         infoListItem: {

--- a/components/src/core/DrawerLayout/DrawerLayout.tsx
+++ b/components/src/core/DrawerLayout/DrawerLayout.tsx
@@ -21,9 +21,9 @@ const useStyles = makeStyles((theme: Theme) =>
         },
         content: {
             width: '100%',
-            transition: 'margin 175ms cubic-bezier(.4, 0, .2, 1)',
+            transition: 'padding 175ms cubic-bezier(.4, 0, .2, 1)',
             [theme.breakpoints.down('xs')]: {
-                marginLeft: '0!important',
+                paddingLeft: '0!important',
             },
         },
     })

--- a/components/src/core/InfoListItem/InfoListItem.styles.tsx
+++ b/components/src/core/InfoListItem/InfoListItem.styles.tsx
@@ -21,7 +21,7 @@ export const useStyles = makeStyles<Theme, InfoListItemProps>((theme: Theme) =>
         root: {
             cursor: (props) => (props.onClick ? 'pointer' : 'inherit'),
             backgroundColor: (props) => props.backgroundColor || 'inherit',
-            minHeight: (props) => (isWrapEnabled(props) ? getHeight(props) : 'unset'),
+            minHeight: (props) => (isWrapEnabled(props) ? getHeight(props) : 'initial'),
             height: (props) => (!isWrapEnabled(props) ? getHeight(props) : 'auto'),
             '&:hover': {
                 backgroundColor: (props) =>

--- a/components/src/core/UserMenu/UserMenu.tsx
+++ b/components/src/core/UserMenu/UserMenu.tsx
@@ -27,7 +27,7 @@ const useStyles = makeStyles((theme: Theme) =>
             width: theme.spacing(5),
         },
         noCursor: {
-            cursor: 'unset',
+            cursor: 'inherit',
         },
     })
 );

--- a/demos/storybook/src/utils.tsx
+++ b/demos/storybook/src/utils.tsx
@@ -14,7 +14,7 @@ const getBanner = (): HTMLElement => {
 };
 const setBannerStyle = (display: string): void => getBanner().setAttribute('style', `display: ${display}`);
 
-export const showTopBanner = (): void => setBannerStyle('unset');
+export const showTopBanner = (): void => setBannerStyle('initial');
 export const hideTopBanner = (): void => setBannerStyle('none');
 
 export const selectCanvasTab = (): void => {

--- a/demos/storybook/stories/user-menu/within-a-toolbar.tsx
+++ b/demos/storybook/stories/user-menu/within-a-toolbar.tsx
@@ -10,7 +10,7 @@ export const withinToolbar = (): StoryFnReactReturnType => {
     const useStyles = makeStyles({
         root: {
             height: 40,
-            minHeight: 'unset',
+            minHeight: 'initial',
         },
         title: {
             color: Colors.gray[100],


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes an issue reported by PX Green where the persistent drawer does not close on IE11. This has already been published as @3.0.3

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
Changes proposed in this Pull Request:
- Replace all uses of the 'unset' property value with either 'inherit' or 'initial' - IE does not support the 'unset' value.
- Change drawerLayout to use padding instead of margin on the left. When using margin with width 100%, things get a little weird if you have wide content:
![image](https://user-images.githubusercontent.com/29152776/79452956-fb976580-7fb6-11ea-9d26-182d687de40b.png)
