### PR TITLE
Update verbiage to match Material UI

### DIFF
--- a/docs/ChannelValue.md
+++ b/docs/ChannelValue.md
@@ -36,6 +36,8 @@ import { ChannelValue } from '@pxblue/react-components';
 
 </div>
 
+Any other props supplied will be provided to the root element (native element).
+
 ### Classes
 
 You can override the classes used by PX Blue by passing a `classes` prop. It supports the following keys:

--- a/docs/ChannelValue.md
+++ b/docs/ChannelValue.md
@@ -36,7 +36,7 @@ import { ChannelValue } from '@pxblue/react-components';
 
 </div>
 
-Any other props supplied will be provided to the root element (native element).
+Any other props supplied will be provided to the root element (`span`).
 
 ### Classes
 

--- a/docs/Drawer.md
+++ b/docs/Drawer.md
@@ -55,7 +55,7 @@ const xsDown = useMediaQuery(theme.breakpoints.down('xs'));
 
 </div>
 
-Any other props will be passed to the root element [**Material UI Drawer**](https://material-ui.com/api/drawer/).
+Any other props will be provided to the root element [**Material UI Drawer**](https://material-ui.com/api/drawer/).
 
 The `Drawer` has three `variant`s:
 
@@ -99,7 +99,7 @@ The `<DrawerHeader>` contains the content at the top of the `<Drawer>`. By defau
 
 </div>
 
-Any other props will be passed to the root element [**Material UI Toolbar**](https://material-ui.com/api/toolbar/).
+Any other props will be provided to the root element [**Material UI Toolbar**](https://material-ui.com/api/toolbar/).
 
 #### Classes
 
@@ -129,6 +129,10 @@ import DrawerSubheader from '@pxblue/react-components/core/Drawer';
 </DrawerSubheader>
 ```
 
+### Drawer Subheader API
+
+Any props supplied will be provided to the root element (native element).
+
 ## Drawer Body
 
 The `<DrawerBody>` is a wrapper for the main content of the Drawer. The typical use case is to display `<DrawerNavGroup>` elements, but custom elements (e.g., for spacing) are accepted as well.
@@ -154,6 +158,8 @@ import DrawerBody from '@pxblue/react-components/core/Drawer';
 | classes         | Style overrides                   | `StyleRules` | no       |         |
 
 </div>
+
+Any other props supplied will be provided to the root element (native element).
 
 #### Classes
 
@@ -188,7 +194,7 @@ The `items` property supports nested items to generate collapsible sections in t
 
 </div>
 
-Any other props will be passed to the root element [**Material UI List**](https://material-ui.com/api/list/).
+Any other props will be provided to the root element [**Material UI List**](https://material-ui.com/api/list/).
 
 #### Classes
 
@@ -228,6 +234,8 @@ import DrawerFooter from '@pxblue/react-components/core/Drawer';
 | backgroundColor | The color used for the background | `string` | no       |         |
 
 </div>
+
+Any other props supplied will be provided to the root element (native element).
 
 ## Drawer Nav Item
 
@@ -360,6 +368,8 @@ import { Drawer, DrawerLayout } from '@pxblue/react-components';
 | drawer    | Drawer component to be embedded | `React.ReactNode` | yes      |         |
 
 </div>
+
+Any other props supplied will be provided to the root element (native element).
 
 > **Note on Scrolling**: When using client-side routing in your application, you may notice that the window scroll position does not reset when navigating to new routes. To address this issue, you will need to manually update the scroll position when new pages are loaded. If you are using React Router they have [several examples](https://reacttraining.com/react-router/web/guides/scroll-restoration) on how to implement this in your application.
 

--- a/docs/Drawer.md
+++ b/docs/Drawer.md
@@ -131,7 +131,7 @@ import DrawerSubheader from '@pxblue/react-components/core/Drawer';
 
 ### Drawer Subheader API
 
-Any props supplied will be provided to the root element (native element).
+Any props supplied will be provided to the root element (`div`).
 
 ## Drawer Body
 
@@ -159,7 +159,7 @@ import DrawerBody from '@pxblue/react-components/core/Drawer';
 
 </div>
 
-Any other props supplied will be provided to the root element (native element).
+Any other props supplied will be provided to the root element (`div`).
 
 #### Classes
 
@@ -235,7 +235,7 @@ import DrawerFooter from '@pxblue/react-components/core/Drawer';
 
 </div>
 
-Any other props supplied will be provided to the root element (native element).
+Any other props supplied will be provided to the root element (`div`).
 
 ## Drawer Nav Item
 
@@ -369,7 +369,7 @@ import { Drawer, DrawerLayout } from '@pxblue/react-components';
 
 </div>
 
-Any other props supplied will be provided to the root element (native element).
+Any other props supplied will be provided to the root element (`div`).
 
 > **Note on Scrolling**: When using client-side routing in your application, you may notice that the window scroll position does not reset when navigating to new routes. To address this issue, you will need to manually update the scroll position when new pages are loaded. If you are using React Router they have [several examples](https://reacttraining.com/react-router/web/guides/scroll-restoration) on how to implement this in your application.
 

--- a/docs/EmptyState.md
+++ b/docs/EmptyState.md
@@ -32,7 +32,7 @@ import { EmptyState } from '@pxblue/react-components';
 
 </div>
 
-Any other props supplied will be provided to the root element (native element).
+Any other props supplied will be provided to the root element (`div`).
 
 ### Classes
 

--- a/docs/EmptyState.md
+++ b/docs/EmptyState.md
@@ -32,6 +32,8 @@ import { EmptyState } from '@pxblue/react-components';
 
 </div>
 
+Any other props supplied will be provided to the root element (native element).
+
 ### Classes
 
 You can override the classes used by PX Blue by passing a `classes` prop. It supports the following keys:

--- a/docs/Hero.md
+++ b/docs/Hero.md
@@ -54,6 +54,8 @@ import { Hero } from '@pxblue/react-components';
 
 </div>
 
+Any other props supplied will be provided to the root element (native element).
+
 ### Classes
 
 You can override the classes used by PX Blue by passing a `classes` prop. It supports the following keys:
@@ -93,6 +95,8 @@ import Hero from '@pxblue/react-components/core/Hero';
 | limit     | Max number of children to display  | `number`  | no       | 4       |
 
 </div>
+
+Any other props supplied will be provided to the root element (native element).
 
 ### Classes
 

--- a/docs/Hero.md
+++ b/docs/Hero.md
@@ -54,7 +54,7 @@ import { Hero } from '@pxblue/react-components';
 
 </div>
 
-Any other props supplied will be provided to the root element (native element).
+Any other props supplied will be provided to the root element (`div`).
 
 ### Classes
 
@@ -96,7 +96,7 @@ import Hero from '@pxblue/react-components/core/Hero';
 
 </div>
 
-Any other props supplied will be provided to the root element (native element).
+Any other props supplied will be provided to the root element (`div`).
 
 ### Classes
 

--- a/docs/InfoListItem.md
+++ b/docs/InfoListItem.md
@@ -48,7 +48,7 @@ import * as Colors from '@pxblue/colors';
 
 </div>
 
-Any other props will be passed to the root element [**Material UI ListItem**](https://material-ui.com/api/list-item/).
+Any other props will be provided to the root element [**Material UI ListItem**](https://material-ui.com/api/list-item/).
 
 ### Classes
 

--- a/docs/ListItemTag.md
+++ b/docs/ListItemTag.md
@@ -24,7 +24,7 @@ import { ListItemTag } from '@pxblue/react-components';
 
 </div>
 
-Any other props will be passed to the root element [**Material UI Typography**](https://material-ui.com/api/typography/).
+Any other props will be provided to the root element [**Material UI Typography**](https://material-ui.com/api/typography/).
 
 ### Classes
 

--- a/docs/ScoreCard.md
+++ b/docs/ScoreCard.md
@@ -74,7 +74,7 @@ import { Temp } from '@pxblue/icons-mui';
 
 </div>
 
-Any other props will be passed to the root element [**Material UI Card**](https://material-ui.com/api/card/).
+Any other props will be provided to the root element [**Material UI Card**](https://material-ui.com/api/card/).
 
 ### Classes
 

--- a/docs/Spacer.md
+++ b/docs/Spacer.md
@@ -31,7 +31,7 @@ import { Spacer } from '@pxblue/react-components';
 
 </div>
 
-Any other props supplied will be provided to the root element (native element).
+Any other props supplied will be provided to the root element (`div`).
 
 ### Classes
 

--- a/docs/Spacer.md
+++ b/docs/Spacer.md
@@ -31,6 +31,8 @@ import { Spacer } from '@pxblue/react-components';
 
 </div>
 
+Any other props supplied will be provided to the root element (native element).
+
 ### Classes
 
 You can override the classes used by PX Blue by passing a `classes` prop. It supports the following keys:

--- a/docs/UserMenu.md
+++ b/docs/UserMenu.md
@@ -68,7 +68,7 @@ const avatar = <Avatar><SendIcon/></Avatar>;
 
 </div>
 
-Any other props supplied will be provided to the root element (native element).
+Any other props supplied will be provided to the root element (`div`).
 
 #### User Menu Groups Object
 

--- a/docs/UserMenu.md
+++ b/docs/UserMenu.md
@@ -68,6 +68,8 @@ const avatar = <Avatar><SendIcon/></Avatar>;
 
 </div>
 
+Any other props supplied will be provided to the root element (native element).
+
 #### User Menu Groups Object
 
 The `menuGroups` prop of the `<UserMenu>` includes many properties from the `<DrawerNavGroup>` array found within a `<DrawerBody>`.


### PR DESCRIPTION
<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
Changes proposed in this Pull Request:
- Updating every component with div or span as their root element saying "Any other props supplied will be provided to the root element (native element)."