### PR TITLE
Add additional classes to override

### DIFF
--- a/components/src/core/InfoListItem/InfoListItem.styles.tsx
+++ b/components/src/core/InfoListItem/InfoListItem.styles.tsx
@@ -6,9 +6,12 @@ import { InfoListItemProps } from './InfoListItem';
 export type InfoListItemClasses = {
     root?: string;
     avatar?: string;
+    divider?: string;
     icon?: string;
+    listItemText?: string;
     rightComponent?: string;
     separator?: string;
+    statusStripe?: string;
     subtitle?: string;
     title?: string;
 };

--- a/components/src/core/InfoListItem/InfoListItem.tsx
+++ b/components/src/core/InfoListItem/InfoListItem.tsx
@@ -122,13 +122,13 @@ export const InfoListItem: React.FC<InfoListItemProps> = (props) => {
     return (
         // @ts-ignore
         <ListItem button={hasRipple} className={combine('root')} {...otherListItemProps}>
-            <div className={defaultClasses.statusStripe} />
-            {divider && <Divider className={defaultClasses.divider} />}
+            <div className={combine('statusStripe')} />
+            {divider && <Divider className={combine('divider')} />}
             {(icon || !hidePadding) && getIcon()}
             {leftComponent}
             <ListItemText
                 primary={title}
-                className={defaultClasses.listItemText}
+                className={combine('listItemText')}
                 secondary={getSubtitle()}
                 primaryTypographyProps={{
                     noWrap: !wrapTitle,

--- a/docs/InfoListItem.md
+++ b/docs/InfoListItem.md
@@ -58,8 +58,11 @@ You can override the classes used by PX Blue by passing a `classes` prop. It sup
 | -------------- | --------------------------------------------------- |
 | root           | Styles applied to the root element                  |
 | avatar         | Styles applied to the Avatar element                |
+| divider        | Styles applied to the divider element               |
 | icon           | Styles applied to the icon element                  |
+| listItemText   | Styles applied to the title/subtitle wrapper        |
 | rightComponent | Styles applied to the rightComponent parent element |
 | separator      | Styles applied to subtitle delimiter                |
+| statusStripe   | Styles applied to the status stripe element         |
 | subtitle       | Styles applied to the subtitle element              |
 | title          | Styles applied to the title element                 |


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes #130.

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
Changes proposed in this Pull Request:
- Add overridable classes for statusStripe, divider, and listItemText
- Update docs
