### PR TITLE
Add support for a third line of text on the InfoListItem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## V4.0.2
+
+- Add `info` prop to InfoListItem to support a third line of text.
+
 ## v4.0.1
 
 -   Themes updated to use [@pxblue/colors](https://www.npmjs.com/package/@pxblue/colors) version 3.0.0.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## V4.0.2
 
-- Add `info` prop to InfoListItem to support a third line of text.
+- Add `info` prop to `<InfoListItem>` to support a third line of text.
 
 ## v4.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## V4.0.2
 
 - Adds `info` prop to `<InfoListItem>` to support a third line of text.
-- Change title and description types from `string` to `ReactNode`.
+- Change title and description types from `string` to `ReactNode` for `<EmptyState>`.
 
 ## v4.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## V4.0.2
 
-- Add `info` prop to `<InfoListItem>` to support a third line of text.
+- Adds `info` prop to `<InfoListItem>` to support a third line of text.
 
 ## v4.0.1
 

--- a/components/src/core/InfoListItem/InfoListItem.tsx
+++ b/components/src/core/InfoListItem/InfoListItem.tsx
@@ -36,6 +36,7 @@ export type InfoListItemProps = Omit<Omit<ListItemProps, 'title'>, 'divider'> & 
     statusColor?: string;
     subtitle?: string | Array<string | JSX.Element>;
     subtitleSeparator?: string;
+    info?: string | Array<string | JSX.Element>;
     title: React.ReactNode;
     wrapSubtitle?: boolean;
     wrapTitle?: boolean;
@@ -56,6 +57,7 @@ export const InfoListItem: React.FC<InfoListItemProps> = (props) => {
         ripple,
         subtitle,
         subtitleSeparator,
+        info,
         title,
         wrapSubtitle,
         wrapTitle,
@@ -117,6 +119,20 @@ export const InfoListItem: React.FC<InfoListItemProps> = (props) => {
         return withKeys(separate(renderableSubtitleParts, () => interpunct()));
     };
 
+    const getInfo = (): string | null => {
+        if (!info) {
+            return null;
+        }
+        if (typeof info === 'string') {
+            return info;
+        }
+
+        const infoParts = Array.isArray(info) ? [...info] : [info];
+        const renderableInfoParts = infoParts.splice(0, MAX_SUBTITLE_ELEMENTS);
+
+        return withKeys(separate(renderableInfoParts, () => interpunct()));
+    };
+
     const hasRipple = button === undefined ? (props.onClick && ripple ? true : undefined) : button ? true : undefined;
 
     return (
@@ -129,7 +145,12 @@ export const InfoListItem: React.FC<InfoListItemProps> = (props) => {
             <ListItemText
                 primary={title}
                 className={combine('listItemText')}
-                secondary={getSubtitle()}
+                secondary={
+                    <>
+                        <Typography variant={'body2'}>{getSubtitle()}</Typography>
+                        <Typography variant={'body2'}>{getInfo()}</Typography>
+                    </>
+                }
                 primaryTypographyProps={{
                     noWrap: !wrapTitle,
                     variant: 'body1',
@@ -174,6 +195,10 @@ InfoListItem.propTypes = {
         PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.string, PropTypes.element])),
     ]),
     subtitleSeparator: PropTypes.string,
+    info: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.string, PropTypes.element])),
+    ]),
     title: PropTypes.oneOfType([PropTypes.string, PropTypes.element]).isRequired,
     wrapSubtitle: PropTypes.bool,
     wrapTitle: PropTypes.bool,

--- a/docs/InfoListItem.md
+++ b/docs/InfoListItem.md
@@ -35,13 +35,14 @@ import * as Colors from '@pxblue/colors';
 | hidePadding       | Remove left padding if no icon is used           | `boolean`                            | no       | false          |
 | icon              | A component to render for the icon               | `React.Component`                    | no       |                |
 | iconColor         | Color override for the row icon                  | `string`                             | no       |                |
+| info              | The text to show on the third line               | `string` \| `Array<React.ReactNode>` | no       |                |
 | leftComponent     | Component to render on the left side             | `React.Component`                    | no       |                |
 | onClick           | A function to execute when clicked               | `function`                           | no       |                |
 | rightComponent    | Component to render on the right side            | `React.Component`                    | no       |                |
 | ripple            | Whether to apply material ripple effect on click | `boolean`                            | no       | false          |
 | statusColor       | Status stripe and icon color                     | `string`                             | no       |                |
 | subtitle          | The text to show on the second line              | `string` \| `Array<React.ReactNode>` | no       |                |
-| subtitleSeparator | Separator character for subtitle                 | `string`                             | no       | '·' ('\u00B7') |
+| subtitleSeparator | Separator character for subtitle and info        | `string`                             | no       | '·' ('\u00B7') |
 | title             | The text to show on the first line               | `React.ReactNode`                    | yes      |                |
 | wrapSubtitle      | Whether to wrap subtitle on overflow             | `boolean`                            | no       | false          |
 | wrapTitle         | Whether to wrap title on overflow                | `boolean`                            | no       | false          |


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes #3.

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
Changes proposed in this Pull Request:
- Add 'info' prop to InfoListItem to add support for a third line of text.