### PR TITLE
Update drawer padding for RTL, fix showcase styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## vX.X.X (Version TBD)
+
+- Fixes RTL support issues in the `<DrawerLayout>`/`<Drawer>`
+- Fixes an issue with text wrapping in the `<InfoListItem>` subtitle
+
 ## V4.0.2
 
 - Updates several prop types to `ReactNode` to support wider range of input values.
@@ -32,7 +37,7 @@
 
 -   A few props got renamed to avoid further ambiguities:
     -   `<DrawerNavGroup>` prop `content` has been renamed to `titleContent`.
-    -   Anything controling the look of a `NavItem` / `NestedNavItem`, has been renamed to include 'item' in them. These are inheritable properties that might get confusing in different drawer hierarchy levels. List of affected props:
+    -   Anything controlling the look of a `NavItem` / `NestedNavItem`, has been renamed to include 'item' in them. These are inheritable properties that might get confusing in different drawer hierarchy levels. List of affected props:
 
 | Previous              | Current                   |
 | --------------------- | ------------------------- |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fixes RTL support issues in the `<DrawerLayout>`/`<Drawer>`
 - Fixes an issue with text wrapping in the `<InfoListItem>` subtitle
+- Fixes an issue with hover color alpha channel in `<InfoListItem>`
 
 ## V4.0.2
 

--- a/components/src/core/Drawer/Drawer.tsx
+++ b/components/src/core/Drawer/Drawer.tsx
@@ -260,8 +260,10 @@ export const DrawerComponent: React.FC<DrawerComponentProps> = (props) => {
     useEffect(() => {
         const content = document.getElementById('@@pxb-drawerlayout-content');
         if (content) {
-            content.style.paddingLeft = theme.direction === 'ltr' ? (variant === 'temporary' ? '0px' : `${containerWidth}px`) : `0px`;
-            content.style.paddingRight = theme.direction === 'rtl' ? (variant === 'temporary' ? '0px' : `${containerWidth}px`) : `0px`;
+            content.style.paddingLeft =
+                theme.direction === 'ltr' ? (variant === 'temporary' ? '0px' : `${containerWidth}px`) : `0px`;
+            content.style.paddingRight =
+                theme.direction === 'rtl' ? (variant === 'temporary' ? '0px' : `${containerWidth}px`) : `0px`;
         }
     }, [containerWidth, variant, theme]);
 

--- a/components/src/core/Drawer/Drawer.tsx
+++ b/components/src/core/Drawer/Drawer.tsx
@@ -260,9 +260,10 @@ export const DrawerComponent: React.FC<DrawerComponentProps> = (props) => {
     useEffect(() => {
         const content = document.getElementById('@@pxb-drawerlayout-content');
         if (content) {
-            content.style.paddingLeft = variant === 'temporary' ? '0px' : `${containerWidth}px`;
+            content.style.paddingLeft = theme.direction === 'ltr' ? (variant === 'temporary' ? '0px' : `${containerWidth}px`) : `0px`;
+            content.style.paddingRight = theme.direction === 'rtl' ? (variant === 'temporary' ? '0px' : `${containerWidth}px`) : `0px`;
         }
-    }, [containerWidth, variant]);
+    }, [containerWidth, variant, theme]);
 
     return (
         <Drawer

--- a/components/src/core/InfoListItem/InfoListItem.styles.tsx
+++ b/components/src/core/InfoListItem/InfoListItem.styles.tsx
@@ -45,7 +45,8 @@ export const useStyles = makeStyles<Theme, InfoListItemProps>((theme: Theme) =>
                           props.backgroundColor !== 'transparent'
                             ? color(props.backgroundColor)
                                   .darken(0.08)
-                                  .hex()
+                                  .rgb()
+                                  .string()
                             : 'rgba(0,0,0,0.08)'
                         : undefined,
             },

--- a/demos/showcase/package.json
+++ b/demos/showcase/package.json
@@ -10,6 +10,7 @@
         "@pxblue/icons-mui": "^2.1.0",
         "@pxblue/react-progress-icons": "^2.0.0",
         "@pxblue/react-themes": "^5.0.1",
+        "clsx": "^1.1.1",
         "jss-rtl": "^0.3.0",
         "prop-types": "^15.7.2",
         "react": "^16.8.6",

--- a/demos/showcase/src/App.js
+++ b/demos/showcase/src/App.js
@@ -23,6 +23,7 @@ import {
 } from '@pxblue/react-components';
 
 import top from './topology_40.png';
+import clsx from 'clsx';
 
 const useStyles = makeStyles((theme) =>
     createStyles({
@@ -36,11 +37,15 @@ const useStyles = makeStyles((theme) =>
         listTag: {
             marginRight: theme.spacing(1),
         },
+        iconFlip: {
+            transform: 'scaleX(-1)',
+        },
     })
 );
 
 export const App = () => {
     const theme = useTheme();
+    const rtl = theme.direction === 'rtl';
     const classes = useStyles();
 
     return (
@@ -54,11 +59,22 @@ export const App = () => {
                         headerSubtitle={'High Humidity Alarm'}
                         headerInfo={'4 Devices'}
                         headerFontColor={Colors.white[50]}
-                        actionItems={[<MoreVert onClick={() => alert('something did')} />]}
+                        actionItems={[
+                            <MoreVert
+                                onClick={() => alert('something did')}
+                                className={clsx({ [classes.iconFlip]: rtl })}
+                            />,
+                        ]}
                         badge={
                             <HeroBanner style={{ minWidth: 210 }}>
                                 <Hero
-                                    icon={<Temp fontSize={'inherit'} htmlColor={Colors.gray[500]} />}
+                                    icon={
+                                        <Temp
+                                            fontSize={'inherit'}
+                                            htmlColor={Colors.gray[500]}
+                                            className={clsx({ [classes.iconFlip]: rtl })}
+                                        />
+                                    }
                                     label={'Temperature'}
                                     iconSize={48}
                                     value={98}
@@ -66,7 +82,13 @@ export const App = () => {
                                     fontSize={'normal'}
                                 />
                                 <Hero
-                                    icon={<Humidity fontSize={'inherit'} htmlColor={Colors.blue[300]} />}
+                                    icon={
+                                        <Humidity
+                                            fontSize={'inherit'}
+                                            htmlColor={Colors.blue[300]}
+                                            className={clsx({ [classes.iconFlip]: rtl })}
+                                        />
+                                    }
                                     label={'Humidity'}
                                     value={54}
                                     units={'%'}
@@ -86,7 +108,7 @@ export const App = () => {
                                 fontColor={Colors.red[500]}
                                 iconColor={Colors.red[500]}
                                 title={'1 Alarm'}
-                                icon={<Leaf color={'inherit'} />}
+                                icon={<Leaf color={'inherit'} className={clsx({ [classes.iconFlip]: rtl })} />}
                             />
                             <InfoListItem
                                 dense
@@ -94,13 +116,13 @@ export const App = () => {
                                 fontColor={Colors.blue[500]}
                                 iconColor={Colors.blue[500]}
                                 title={'1 Event'}
-                                icon={<Leaf color={'inherit'} />}
+                                icon={<Leaf color={'inherit'} className={clsx({ [classes.iconFlip]: rtl })} />}
                             />
                             <InfoListItem
                                 dense
                                 style={{ height: 36 }}
                                 title={'Online'}
-                                icon={<Leaf color={'inherit'} />}
+                                icon={<Leaf color={'inherit'} className={clsx({ [classes.iconFlip]: rtl })} />}
                             />
                         </List>
                     </ScoreCard>
@@ -111,7 +133,12 @@ export const App = () => {
                         headerSubtitle={'Normal'}
                         headerInfo={'4 Devices'}
                         headerFontColor={Colors.white[50]}
-                        actionItems={[<MoreVert onClick={() => alert('something did')} />]}
+                        actionItems={[
+                            <MoreVert
+                                onClick={() => alert('something did')}
+                                className={clsx({ [classes.iconFlip]: rtl })}
+                            />,
+                        ]}
                         badge={
                             <HeroBanner>
                                 <Hero
@@ -134,7 +161,7 @@ export const App = () => {
                                 dense
                                 style={{ height: 36 }}
                                 title={'0 Alarms'}
-                                icon={<Leaf color={'inherit'} />}
+                                icon={<Leaf color={'inherit'} className={clsx({ [classes.iconFlip]: rtl })} />}
                             />
                             <InfoListItem
                                 dense
@@ -142,13 +169,13 @@ export const App = () => {
                                 fontColor={Colors.blue[500]}
                                 iconColor={Colors.blue[500]}
                                 title={'1 Event'}
-                                icon={<Leaf color={'inherit'} />}
+                                icon={<Leaf color={'inherit'} className={clsx({ [classes.iconFlip]: rtl })} />}
                             />
                             <InfoListItem
                                 dense
                                 style={{ height: 36 }}
                                 title={'Online'}
-                                icon={<Leaf color={'inherit'} />}
+                                icon={<Leaf color={'inherit'} className={clsx({ [classes.iconFlip]: rtl })} />}
                             />
                         </List>
                     </ScoreCard>
@@ -165,18 +192,37 @@ export const App = () => {
                                 fontSize={'normal'}
                             />
                             <Hero
-                                icon={<Pie color={Colors.blue[500]} percent={65} size={36} />}
+                                icon={
+                                    <Pie
+                                        color={Colors.blue[500]}
+                                        percent={65}
+                                        size={36}
+                                        className={clsx({ [classes.iconFlip]: rtl })}
+                                    />
+                                }
                                 label={'Load'}
                                 fontSize={'normal'}
                             >
                                 <ChannelValue
                                     value={65}
                                     units={'%'}
-                                    icon={<Trend htmlColor={Colors.red[500]} fontSize={'inherit'} />}
+                                    icon={
+                                        <Trend
+                                            htmlColor={Colors.red[500]}
+                                            fontSize={'inherit'}
+                                            className={clsx({ [classes.iconFlip]: rtl })}
+                                        />
+                                    }
                                 />
                             </Hero>
                             <Hero
-                                icon={<Timer fontSize={'inherit'} color={'inherit'} />}
+                                icon={
+                                    <Timer
+                                        fontSize={'inherit'}
+                                        color={'inherit'}
+                                        className={clsx({ [classes.iconFlip]: rtl })}
+                                    />
+                                }
                                 label={'Estimated'}
                                 fontSize={'normal'}
                             >
@@ -184,7 +230,14 @@ export const App = () => {
                                 <ChannelValue value={26} units={'m'} />
                             </Hero>
                             <Hero
-                                icon={<Battery color={Colors.blue[500]} percent={100} size={36} />}
+                                icon={
+                                    <Battery
+                                        color={Colors.blue[500]}
+                                        percent={100}
+                                        size={36}
+                                        className={clsx({ [classes.iconFlip]: rtl })}
+                                    />
+                                }
                                 value={'Full'}
                                 label={'Battery'}
                                 fontSize={'normal'}
@@ -198,7 +251,7 @@ export const App = () => {
                             divider={'full'}
                             statusColor={Colors.green[500]}
                             subtitleSeparator={'/'}
-                            icon={<Leaf color={'inherit'} />}
+                            icon={<Leaf color={'inherit'} className={clsx({ [classes.iconFlip]: rtl })} />}
                             rightComponent={<ChannelValue fontSize={16} value={'Online, ESS+'} />}
                         />
                         <InfoListItem
@@ -206,7 +259,7 @@ export const App = () => {
                             divider={'full'}
                             avatar
                             subtitle={['Phase A', 'Phase B', 'Phase C']}
-                            icon={<VoltageCircled />}
+                            icon={<VoltageCircled className={clsx({ [classes.iconFlip]: rtl })} />}
                             rightComponent={
                                 <span>
                                     <ChannelValue fontSize={16} value={478} units={'V'} />,{' '}
@@ -222,7 +275,7 @@ export const App = () => {
                             statusColor={Colors.red[500]}
                             fontColor={Colors.red[500]}
                             subtitle={['Phase A', 'Phase B', 'Phase C']}
-                            icon={<VoltageCircled color={'inherit'} />}
+                            icon={<VoltageCircled color={'inherit'} className={clsx({ [classes.iconFlip]: rtl })} />}
                             rightComponent={
                                 <span style={{ color: Colors.red[500] }}>
                                     <ListItemTag label={'monitored'} classes={{ root: classes.listTag }} />
@@ -236,7 +289,7 @@ export const App = () => {
                             dense
                             title={'Output Current'}
                             divider={'full'}
-                            icon={<CurrentCircled color={'inherit'} />}
+                            icon={<CurrentCircled color={'inherit'} className={clsx({ [classes.iconFlip]: rtl })} />}
                             rightComponent={
                                 <span>
                                     <ChannelValue fontSize={16} value={15} units={'A'} />,{' '}
@@ -248,7 +301,7 @@ export const App = () => {
                         <InfoListItem
                             dense
                             title={'Temperature'}
-                            icon={<Temp />}
+                            icon={<Temp className={clsx({ [classes.iconFlip]: rtl })} />}
                             rightComponent={
                                 <div style={{ display: 'flex', alignItems: 'center' }}>
                                     <ListItemTag
@@ -269,7 +322,12 @@ export const App = () => {
                                     />
                                     <ChannelValue
                                         fontSize={16}
-                                        icon={<Trend htmlColor={Colors.red[500]} />}
+                                        icon={
+                                            <Trend
+                                                htmlColor={Colors.red[500]}
+                                                className={clsx({ [classes.iconFlip]: rtl })}
+                                            />
+                                        }
                                         value={68}
                                         units={'°F'}
                                     />
@@ -280,11 +338,15 @@ export const App = () => {
                 </Card>
                 <Card style={{ marginTop: theme.spacing(1), padding: theme.spacing(3) }}>
                     <EmptyState
-                        icon={<DevicesIcon fontSize={'inherit'} />}
+                        icon={<DevicesIcon fontSize={'inherit'} className={clsx({ [classes.iconFlip]: rtl })} />}
                         title={'No Devices'}
                         description={'Contact your local admin for details'}
                         actions={
-                            <Button variant="contained" color="primary" startIcon={<Add />}>
+                            <Button
+                                variant="contained"
+                                color="primary"
+                                startIcon={<Add className={clsx({ [classes.iconFlip]: rtl })} />}
+                            >
                                 Add Device
                             </Button>
                         }
@@ -297,10 +359,10 @@ export const App = () => {
                             {
                                 title: 'Guides',
                                 itemID: 'Guides',
-                                icon: <DevicesIcon />,
+                                icon: <DevicesIcon className={clsx({ [classes.iconFlip]: rtl })} />,
                                 rightComponent: <ListItemTag label={'new'} onClick={() => alert('You clicked me.')} />,
-                                expandIcon: <Add />,
-                                collapseIcon: <Remove />,
+                                expandIcon: <Add className={clsx({ [classes.iconFlip]: rtl })} />,
+                                collapseIcon: <Remove className={clsx({ [classes.iconFlip]: rtl })} />,
                                 items: [
                                     {
                                         title: 'Installation Manual',
@@ -325,7 +387,7 @@ export const App = () => {
                             {
                                 title: 'Quality Control',
                                 itemID: 'Quality Control',
-                                icon: <Settings />,
+                                icon: <Settings className={clsx({ [classes.iconFlip]: rtl })} />,
                                 items: [
                                     {
                                         title: 'Training',
@@ -340,7 +402,7 @@ export const App = () => {
                             {
                                 title: 'Report',
                                 itemID: 'Report',
-                                icon: <ListIcon />,
+                                icon: <ListIcon className={clsx({ [classes.iconFlip]: rtl })} />,
                                 divider: false,
                                 items: [
                                     {

--- a/demos/showcase/src/App.js
+++ b/demos/showcase/src/App.js
@@ -24,18 +24,20 @@ import {
 
 import top from './topology_40.png';
 
-const useStyles = makeStyles((theme) => createStyles({
-    scorecard: {
-        flex: '1 1 0px',
-        maxWidth: 400,
-        '&:not(:first-child)':{
-            marginLeft: theme.spacing(2),
-        }
-    },
-    listTag:{
-        marginRight: theme.spacing(1),
-    }
-}));
+const useStyles = makeStyles((theme) =>
+    createStyles({
+        scorecard: {
+            flex: '1 1 0px',
+            maxWidth: 400,
+            '&:not(:first-child)': {
+                marginLeft: theme.spacing(2),
+            },
+        },
+        listTag: {
+            marginRight: theme.spacing(1),
+        },
+    })
+);
 
 export const App = () => {
     const theme = useTheme();
@@ -75,7 +77,7 @@ export const App = () => {
                         }
                         badgeOffset={0}
                         actionRow={<InfoListItem dense chevron title={'More'} hidePadding />}
-                        classes={{root: classes.scorecard}}
+                        classes={{ root: classes.scorecard }}
                     >
                         <List style={{ padding: '16px 0' }}>
                             <InfoListItem
@@ -125,7 +127,7 @@ export const App = () => {
                         }
                         badgeOffset={-52}
                         actionRow={<InfoListItem dense chevron title={'View Location'} hidePadding />}
-                        classes={{root: classes.scorecard}}
+                        classes={{ root: classes.scorecard }}
                     >
                         <List style={{ padding: '16px 0' }}>
                             <InfoListItem
@@ -223,7 +225,7 @@ export const App = () => {
                             icon={<VoltageCircled color={'inherit'} />}
                             rightComponent={
                                 <span style={{ color: Colors.red[500] }}>
-                                    <ListItemTag label={'monitored'} classes={{root: classes.listTag}} />
+                                    <ListItemTag label={'monitored'} classes={{ root: classes.listTag }} />
                                     <ChannelValue fontSize={16} value={480} units={'V'} />,{' '}
                                     <ChannelValue fontSize={16} value={480} units={'V'} />,{' '}
                                     <ChannelValue fontSize={16} value={480} units={'V'} />
@@ -255,7 +257,7 @@ export const App = () => {
                                         fontColor={
                                             theme.palette.type === 'light' ? Colors.blue[700] : Colors.green['500']
                                         }
-                                        classes={{root: classes.listTag}}
+                                        classes={{ root: classes.listTag }}
                                     />
                                     <ListItemTag
                                         label={'OVERHEAT'}
@@ -263,7 +265,7 @@ export const App = () => {
                                         onClick={(_) => {
                                             alert('You clicked me.');
                                         }}
-                                        classes={{root: classes.listTag}}
+                                        classes={{ root: classes.listTag }}
                                     />
                                     <ChannelValue
                                         fontSize={16}

--- a/demos/showcase/src/App.js
+++ b/demos/showcase/src/App.js
@@ -278,11 +278,6 @@ export const App = () => {
                         />
                     </List>
                 </Card>
-                {/* <DrawerLayout 
-                    drawer={<NavigationDrawer/>}
-                >
-                    <span>Hello World</span>
-                    </DrawerLayout> */}
                 <Card style={{ marginTop: theme.spacing(1), padding: theme.spacing(3) }}>
                     <EmptyState
                         icon={<DevicesIcon fontSize={'inherit'} />}

--- a/demos/showcase/src/App.js
+++ b/demos/showcase/src/App.js
@@ -4,7 +4,7 @@ import { Add, Remove, List as ListIcon, Settings, MoreVert } from '@material-ui/
 import Trend from '@material-ui/icons/TrendingUp';
 import Timer from '@material-ui/icons/Timer';
 import DevicesIcon from '@material-ui/icons/Devices';
-import { useTheme } from '@material-ui/core/styles';
+import { useTheme, makeStyles, createStyles } from '@material-ui/core/styles';
 import { List, Card, Button } from '@material-ui/core';
 
 import * as Colors from '@pxblue/colors';
@@ -24,15 +24,28 @@ import {
 
 import top from './topology_40.png';
 
+const useStyles = makeStyles((theme) => createStyles({
+    scorecard: {
+        flex: '1 1 0px',
+        maxWidth: 400,
+        '&:not(:first-child)':{
+            marginLeft: theme.spacing(2),
+        }
+    },
+    listTag:{
+        marginRight: theme.spacing(1),
+    }
+}));
+
 export const App = () => {
     const theme = useTheme();
+    const classes = useStyles();
 
     return (
         <div style={{ display: 'flex', flexDirection: 'column' }}>
             <div style={{ padding: theme.spacing(), flex: 1 }}>
                 <div style={{ display: 'flex', flexWrap: 'wrap' }}>
                     <ScoreCard
-                        style={{ maxWidth: 400 }}
                         headerColor={Colors.red[500]}
                         headerBackgroundImage={top}
                         headerTitle={'Substation 3'}
@@ -62,6 +75,7 @@ export const App = () => {
                         }
                         badgeOffset={0}
                         actionRow={<InfoListItem dense chevron title={'More'} hidePadding />}
+                        classes={{root: classes.scorecard}}
                     >
                         <List style={{ padding: '16px 0' }}>
                             <InfoListItem
@@ -89,7 +103,6 @@ export const App = () => {
                         </List>
                     </ScoreCard>
                     <ScoreCard
-                        style={{ flex: '1 1 0px', maxWidth: 400, marginLeft: theme.spacing(1) }}
                         headerColor={Colors.blue[500]}
                         headerBackgroundImage={top}
                         headerTitle={'Substation 3'}
@@ -112,6 +125,7 @@ export const App = () => {
                         }
                         badgeOffset={-52}
                         actionRow={<InfoListItem dense chevron title={'View Location'} hidePadding />}
+                        classes={{root: classes.scorecard}}
                     >
                         <List style={{ padding: '16px 0' }}>
                             <InfoListItem
@@ -209,7 +223,7 @@ export const App = () => {
                             icon={<VoltageCircled color={'inherit'} />}
                             rightComponent={
                                 <span style={{ color: Colors.red[500] }}>
-                                    <ListItemTag label={'monitored'} style={{ marginRight: 8 }} />
+                                    <ListItemTag label={'monitored'} classes={{root: classes.listTag}} />
                                     <ChannelValue fontSize={16} value={480} units={'V'} />,{' '}
                                     <ChannelValue fontSize={16} value={480} units={'V'} />,{' '}
                                     <ChannelValue fontSize={16} value={480} units={'V'} />
@@ -241,15 +255,15 @@ export const App = () => {
                                         fontColor={
                                             theme.palette.type === 'light' ? Colors.blue[700] : Colors.green['500']
                                         }
-                                        style={{ marginRight: theme.spacing(1) }}
+                                        classes={{root: classes.listTag}}
                                     />
                                     <ListItemTag
-                                        style={{ marginRight: theme.spacing(1) }}
                                         label={'OVERHEAT'}
                                         backgroundColor={Colors.red['500']}
                                         onClick={(_) => {
                                             alert('You clicked me.');
                                         }}
+                                        classes={{root: classes.listTag}}
                                     />
                                     <ChannelValue
                                         fontSize={16}
@@ -262,6 +276,11 @@ export const App = () => {
                         />
                     </List>
                 </Card>
+                {/* <DrawerLayout 
+                    drawer={<NavigationDrawer/>}
+                >
+                    <span>Hello World</span>
+                    </DrawerLayout> */}
                 <Card style={{ marginTop: theme.spacing(1), padding: theme.spacing(3) }}>
                     <EmptyState
                         icon={<DevicesIcon fontSize={'inherit'} />}

--- a/demos/showcase/src/components/RTLProvider.js
+++ b/demos/showcase/src/components/RTLProvider.js
@@ -18,7 +18,7 @@ export const RTLThemeProvider = (props) => {
             <ThemeProvider
                 theme={createMuiTheme(
                     Object.assign(store.getState().theme === 'light' ? PXBThemes.blue : PXBThemes.blueDark, {
-                        direction: props.rtl ? 'rtl' : 'lrt',
+                        direction: props.rtl ? 'rtl' : 'ltr',
                     })
                 )}
             >

--- a/demos/showcase/src/components/SharedAppBar.js
+++ b/demos/showcase/src/components/SharedAppBar.js
@@ -1,4 +1,4 @@
-import { AppBar, Hidden, Toolbar, Typography, IconButton, Tooltip } from '@material-ui/core';
+import { AppBar, Hidden, Toolbar, Typography, IconButton, Tooltip, makeStyles, createStyles } from '@material-ui/core';
 import { Email, Menu, Settings, InvertColors, SwapHoriz } from '@material-ui/icons';
 import Avatar from '@material-ui/core/Avatar';
 import SendIcon from '@material-ui/icons/Send';
@@ -8,15 +8,22 @@ import { store } from '../store';
 
 import { Spacer, UserMenu } from '@pxblue/react-components';
 
+const useStyles = makeStyles((theme) => createStyles({
+    menuButton:{
+        marginRight: theme.spacing(4)
+    }
+}));
+
 export const SharedAppBar = (props) => {
     const { onClick } = props;
     const theme = useTheme();
+    const classes = useStyles();
 
     return (
         <AppBar position={'sticky'} color={'primary'}>
             <Toolbar style={{ padding: `0 ${theme.spacing(2)}px` }}>
                 <Hidden smUp>
-                    <Menu style={{ marginRight: theme.spacing(4) }} onClick={onClick} />
+                    <Menu className={classes.menuButton} onClick={onClick} />
                 </Hidden>
                 <Typography variant={'h6'}>Showcase</Typography>
                 <Spacer flex={1} />

--- a/demos/showcase/src/components/SharedAppBar.js
+++ b/demos/showcase/src/components/SharedAppBar.js
@@ -8,11 +8,13 @@ import { store } from '../store';
 
 import { Spacer, UserMenu } from '@pxblue/react-components';
 
-const useStyles = makeStyles((theme) => createStyles({
-    menuButton:{
-        marginRight: theme.spacing(4)
-    }
-}));
+const useStyles = makeStyles((theme) =>
+    createStyles({
+        menuButton: {
+            marginRight: theme.spacing(4),
+        },
+    })
+);
 
 export const SharedAppBar = (props) => {
     const { onClick } = props;

--- a/demos/showcase/src/router/NavigationDrawer.js
+++ b/demos/showcase/src/router/NavigationDrawer.js
@@ -1,9 +1,9 @@
+import React, { useState } from 'react';
 import top from '../topology_40.png';
 import { Gavel, Help, List as ListIcon, Menu, NotificationsActive, Public, Settings } from '@material-ui/icons';
-import { Divider, MenuItem, Select, useMediaQuery } from '@material-ui/core';
+import { Divider, MenuItem, Select, useMediaQuery, makeStyles } from '@material-ui/core';
 import { Device } from '@pxblue/icons-mui';
 import EatonLogo from '../EatonLogo.svg';
-import React, { useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import { useTheme } from '@material-ui/core/styles';
 import * as Colors from '@pxblue/colors';
@@ -16,6 +16,7 @@ import {
     DrawerHeader,
     DrawerSubheader,
 } from '@pxblue/react-components';
+import clsx from 'clsx';
 
 export const titleList = [
     'Overview',
@@ -29,11 +30,19 @@ export const titleList = [
     'All Facilities',
 ];
 
+const useStyles = makeStyles({
+    iconFlip: {
+        transform: 'scaleX(-1)',
+    },
+});
+
 export const NavigationDrawer = (props) => {
     const { open, setOpen } = props;
+    const classes = useStyles();
     const [location, setLocation] = useState(0);
     const [route, setRoute] = useState(0);
     const theme = useTheme();
+    const rtl = theme.direction === 'rtl';
     const history = useHistory();
     const xsDown = useMediaQuery(theme.breakpoints.down('xs'));
     const locations = ['All Locations', 'Gary Steelworks', 'Semaine Prochaine'];
@@ -60,9 +69,8 @@ export const NavigationDrawer = (props) => {
                 backgroundColor={Colors.blue[500]}
                 fontColor={Colors.white[50]}
                 backgroundImage={top}
-                icon={<Menu />}
+                icon={<Menu className={clsx({ [classes.iconFlip]: rtl })} />}
                 onIconClick={() => setOpen(!open)}
-            />
             />
             <DrawerSubheader>
                 <Select
@@ -83,7 +91,7 @@ export const NavigationDrawer = (props) => {
                         {
                             title: titleList[0],
                             itemID: titleList[0],
-                            icon: <ListIcon />,
+                            icon: <ListIcon className={clsx({ [classes.iconFlip]: rtl })} />,
                             onClick: () => {
                                 navigate(0);
                                 if (xsDown) setOpen(false);
@@ -93,7 +101,7 @@ export const NavigationDrawer = (props) => {
                             title: titleList[1],
                             itemID: titleList[1],
                             subtitle: '2 Alarms',
-                            icon: <NotificationsActive />,
+                            icon: <NotificationsActive className={clsx({ [classes.iconFlip]: rtl })} />,
                             onClick: () => {
                                 navigate(1);
                                 if (xsDown) setOpen(false);
@@ -102,7 +110,7 @@ export const NavigationDrawer = (props) => {
                         {
                             title: titleList[2],
                             itemID: titleList[2],
-                            icon: <Public />,
+                            icon: <Public className={clsx({ [classes.iconFlip]: rtl })} />,
                             onClick: () => navigate(2),
                             onItemSelect: () => {}, // to prevent auto collapse on click
                             items: [
@@ -127,7 +135,7 @@ export const NavigationDrawer = (props) => {
                         {
                             title: titleList[3],
                             itemID: titleList[3],
-                            icon: <Device />,
+                            icon: <Device className={clsx({ [classes.iconFlip]: rtl })} />,
                             onClick: () => {
                                 navigate(3);
                                 if (xsDown) setOpen(false);
@@ -148,7 +156,7 @@ export const NavigationDrawer = (props) => {
                         {
                             title: titleList[4],
                             itemID: titleList[4],
-                            icon: <Settings />,
+                            icon: <Settings className={clsx({ [classes.iconFlip]: rtl })} />,
                             onClick: () => {
                                 navigate(4);
                                 if (xsDown) setOpen(false);
@@ -157,7 +165,7 @@ export const NavigationDrawer = (props) => {
                         {
                             title: titleList[5],
                             itemID: titleList[5],
-                            icon: <Gavel />,
+                            icon: <Gavel className={clsx({ [classes.iconFlip]: rtl })} />,
                             onClick: () => {
                                 navigate(5);
                                 if (xsDown) setOpen(false);
@@ -166,7 +174,7 @@ export const NavigationDrawer = (props) => {
                         {
                             title: titleList[6],
                             itemID: titleList[6],
-                            icon: <Help />,
+                            icon: <Help className={clsx({ [classes.iconFlip]: rtl })} />,
                             onClick: () => {
                                 navigate(6);
                                 if (xsDown) setOpen(false);

--- a/demos/showcase/yarn.lock
+++ b/demos/showcase/yarn.lock
@@ -2662,6 +2662,11 @@ clsx@^1.0.2:
   resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.1.0.tgz#62937c6adfea771247c34b54d320fb99624f5702"
   integrity sha512-3avwM37fSK5oP6M5rQ9CNe99lwxhXDOeSWVPAOYF6OazUTgZCMb0yWlJpmdD74REy1gkEaFiub2ULv4fq9GUhA==
 
+clsx@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.1.1.tgz#98b3134f9abbdf23b2663491ace13c5c03a73188"
+  integrity sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA==
+
 co@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
For PXBLUE-1456.

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Update the drawer component to conditionally do left/right padding on the DrawerLayout based on theme direction
- Update the showcase demo to move styles into JSS classes
    - This lets the JSS plugin automatically flip the styles when we go to RTL
- Add logic to flip all of the icons (Except for GradeA since it has text in it, not that it really makes a difference)
    - The Pie progress icon does't flip because of a bug (https://github.com/pxblue/icons/issues/65)
- Fixes a bug in the ILI hover color (doesn't work when using rgba color for background)
    - Reported by Anjali today

<!-- Include screenshots if they will help illustrate the changes in this PR -->
#### Screenshots:
![image](https://user-images.githubusercontent.com/29152776/88066236-8601df00-cb3b-11ea-8cff-bf3c1155425a.png)

> I'm still looking into an alternative for linking the DrawerLayout and the Drawer other than doing the lookup by ID, but this works for now keeping the existing approach.

