### PR TITLE
Refactor drawerLayout to use ID and React context

### DIFF
--- a/components/src/core/Drawer/Drawer.tsx
+++ b/components/src/core/Drawer/Drawer.tsx
@@ -118,7 +118,7 @@ export const DrawerComponent: React.FC<DrawerComponentProps> = (props) => {
     let hoverDelay: NodeJS.Timeout;
     const defaultClasses = useStyles(props);
     const theme = useTheme();
-    const {onPaddingChange} = useDrawerLayout();
+    const { onPaddingChange } = useDrawerLayout();
     const [hover, setHover] = useState(false);
     const {
         activeItem,
@@ -264,7 +264,7 @@ export const DrawerComponent: React.FC<DrawerComponentProps> = (props) => {
     const contentWidth = width || defaultContentWidth;
 
     useEffect(() => {
-         onPaddingChange(layoutID, variant === 'temporary' ? 0 : containerWidth);
+        onPaddingChange(layoutID, variant === 'temporary' ? 0 : containerWidth);
     }, [containerWidth, variant, theme]);
 
     return (

--- a/components/src/core/Drawer/Drawer.tsx
+++ b/components/src/core/Drawer/Drawer.tsx
@@ -103,11 +103,12 @@ export type PXBlueDrawerNavGroupInheritableProperties = {
 
 export type DrawerComponentProps = {
     classes?: DrawerClasses;
+
+    // Describes if this Drawer is used outside of a DrawerLayout
+    noLayout?: boolean;
+
     // Controls the open/closed state of the drawer
     open: boolean;
-
-    // Refers to the id of the parent DrawerLayout
-    layoutID?: number | string;
 
     // Sets the width of the drawer (in px) when open
     width?: number;
@@ -135,9 +136,9 @@ export const DrawerComponent: React.FC<DrawerComponentProps> = (props) => {
         InfoListItemProps,
         itemFontColor,
         itemIconColor,
-        layoutID,
         nestedBackgroundColor,
         nestedDivider,
+        noLayout = false,
         open,
         onItemSelect,
         ripple,
@@ -264,8 +265,8 @@ export const DrawerComponent: React.FC<DrawerComponentProps> = (props) => {
     const contentWidth = width || defaultContentWidth;
 
     useEffect(() => {
-        onPaddingChange(layoutID, variant === 'temporary' ? 0 : containerWidth);
-    }, [containerWidth, variant, theme]);
+        if (!noLayout) onPaddingChange(variant === 'temporary' ? 0 : containerWidth);
+    }, [containerWidth, variant, noLayout]);
 
     return (
         <Drawer

--- a/components/src/core/Drawer/Drawer.tsx
+++ b/components/src/core/Drawer/Drawer.tsx
@@ -5,6 +5,7 @@ import { DrawerBodyProps } from './DrawerBody';
 import clsx from 'clsx';
 import PropTypes from 'prop-types';
 import { InfoListItemProps as BaseInfoListItemProps } from '../InfoListItem';
+import { useDrawerLayout } from '../DrawerLayout/contexts/DrawerLayoutContextProvider';
 
 const useStyles = makeStyles({
     paper: {
@@ -105,6 +106,9 @@ export type DrawerComponentProps = {
     // Controls the open/closed state of the drawer
     open: boolean;
 
+    // Refers to the id of the parent DrawerLayout
+    layoutID?: number | string;
+
     // Sets the width of the drawer (in px) when open
     width?: number;
 } & PXBlueDrawerNavGroupInheritableProperties &
@@ -114,6 +118,7 @@ export const DrawerComponent: React.FC<DrawerComponentProps> = (props) => {
     let hoverDelay: NodeJS.Timeout;
     const defaultClasses = useStyles(props);
     const theme = useTheme();
+    const {onPaddingChange} = useDrawerLayout();
     const [hover, setHover] = useState(false);
     const {
         activeItem,
@@ -130,6 +135,7 @@ export const DrawerComponent: React.FC<DrawerComponentProps> = (props) => {
         InfoListItemProps,
         itemFontColor,
         itemIconColor,
+        layoutID,
         nestedBackgroundColor,
         nestedDivider,
         open,
@@ -258,13 +264,7 @@ export const DrawerComponent: React.FC<DrawerComponentProps> = (props) => {
     const contentWidth = width || defaultContentWidth;
 
     useEffect(() => {
-        const content = document.getElementById('@@pxb-drawerlayout-content');
-        if (content) {
-            content.style.paddingLeft =
-                theme.direction === 'ltr' ? (variant === 'temporary' ? '0px' : `${containerWidth}px`) : `0px`;
-            content.style.paddingRight =
-                theme.direction === 'rtl' ? (variant === 'temporary' ? '0px' : `${containerWidth}px`) : `0px`;
-        }
+         onPaddingChange(layoutID, variant === 'temporary' ? 0 : containerWidth);
     }, [containerWidth, variant, theme]);
 
     return (

--- a/components/src/core/DrawerLayout/DrawerLayout.tsx
+++ b/components/src/core/DrawerLayout/DrawerLayout.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement, HTMLAttributes, useState } from 'react';
-import { createStyles, makeStyles, Theme, useTheme } from '@material-ui/core/styles';
+import { makeStyles, useTheme } from '@material-ui/core/styles';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import { DrawerComponentProps } from '../Drawer/Drawer';
@@ -32,10 +32,12 @@ export type DrawerLayoutProps = HTMLAttributes<HTMLDivElement> & {
     classes?: DrawerLayoutClasses;
     // Drawer component to be embedded
     drawer: ReactElement<DrawerComponentProps>;
+    // ID used to link this DrawerLayout to a Drawer
+    layoutID?: number | string;
 };
 
 export const DrawerLayout: React.FC<DrawerLayoutProps> = (props) => {
-    const { children, drawer, classes, ...otherDivProps } = props;
+    const { children, drawer, layoutID, classes, ...otherDivProps } = props;
     const theme = useTheme();
     const [padding, setPadding] = useState(0);
     const defaultClasses = useStyles();
@@ -45,7 +47,13 @@ export const DrawerLayout: React.FC<DrawerLayoutProps> = (props) => {
     style.paddingRight = theme.direction === 'rtl' ? padding : 0;
 
     return (
-        <DrawerLayoutContext.Provider value={{ padding: 0, onPaddingChange: (id: number | string, width: number) => { if (id === props.id) setPadding(width) } }}>
+        <DrawerLayoutContext.Provider
+            value={{
+                onPaddingChange: (id: number | string, width: number): void => {
+                    if (id === layoutID) setPadding(width);
+                },
+            }}
+        >
             <div className={clsx(defaultClasses.root, classes.root)} {...otherDivProps}>
                 <div className={clsx(defaultClasses.drawer, classes.drawer)}>{drawer}</div>
                 <div className={clsx(defaultClasses.content, classes.content)} style={style}>

--- a/components/src/core/DrawerLayout/DrawerLayout.tsx
+++ b/components/src/core/DrawerLayout/DrawerLayout.tsx
@@ -1,30 +1,26 @@
-import React, { ReactElement, HTMLAttributes } from 'react';
+import React, { ReactElement, HTMLAttributes, useState } from 'react';
 import { createStyles, makeStyles, Theme, useTheme } from '@material-ui/core/styles';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import { DrawerComponentProps } from '../Drawer/Drawer';
+import { DrawerLayoutContext } from './contexts/DrawerLayoutContextProvider';
 
-const useStyles = makeStyles((theme: Theme) =>
-    createStyles({
-        root: {
-            display: 'flex',
-            width: '100%',
-        },
-        drawer: {
-            display: 'flex',
-            position: 'fixed',
-            height: '100%',
-            alignItems: 'stretch',
-        },
-        content: {
-            width: '100%',
-            transition: 'padding 175ms cubic-bezier(.4, 0, .2, 1)',
-            [theme.breakpoints.down('xs')]: {
-                paddingLeft: '0!important',
-            },
-        },
-    })
-);
+const useStyles = makeStyles({
+    root: {
+        display: 'flex',
+        width: '100%',
+    },
+    drawer: {
+        display: 'flex',
+        position: 'fixed',
+        height: '100%',
+        alignItems: 'stretch',
+    },
+    content: {
+        width: '100%',
+        transition: 'padding 175ms cubic-bezier(.4, 0, .2, 1)',
+    },
+});
 
 export type DrawerLayoutClasses = {
     root?: string;
@@ -40,14 +36,23 @@ export type DrawerLayoutProps = HTMLAttributes<HTMLDivElement> & {
 
 export const DrawerLayout: React.FC<DrawerLayoutProps> = (props) => {
     const { children, drawer, classes, ...otherDivProps } = props;
-    const defaultClasses = useStyles(useTheme());
+    const theme = useTheme();
+    const [padding, setPadding] = useState(0);
+    const defaultClasses = useStyles();
+
+    const style = { paddingLeft: 0, paddingRight: 0 };
+    style.paddingLeft = theme.direction === 'ltr' ? padding : 0;
+    style.paddingRight = theme.direction === 'rtl' ? padding : 0;
+
     return (
-        <div className={clsx(defaultClasses.root, classes.root)} {...otherDivProps}>
-            <div className={clsx(defaultClasses.drawer, classes.drawer)}>{drawer}</div>
-            <div id={'@@pxb-drawerlayout-content'} className={clsx(defaultClasses.content, classes.content)}>
-                {children}
+        <DrawerLayoutContext.Provider value={{ padding: 0, onPaddingChange: (id: number | string, width: number) => { if (id === props.id) setPadding(width) } }}>
+            <div className={clsx(defaultClasses.root, classes.root)} {...otherDivProps}>
+                <div className={clsx(defaultClasses.drawer, classes.drawer)}>{drawer}</div>
+                <div className={clsx(defaultClasses.content, classes.content)} style={style}>
+                    {children}
+                </div>
             </div>
-        </div>
+        </DrawerLayoutContext.Provider>
     );
 };
 

--- a/components/src/core/DrawerLayout/DrawerLayout.tsx
+++ b/components/src/core/DrawerLayout/DrawerLayout.tsx
@@ -32,12 +32,10 @@ export type DrawerLayoutProps = HTMLAttributes<HTMLDivElement> & {
     classes?: DrawerLayoutClasses;
     // Drawer component to be embedded
     drawer: ReactElement<DrawerComponentProps>;
-    // ID used to link this DrawerLayout to a Drawer
-    layoutID?: number | string;
 };
 
 export const DrawerLayout: React.FC<DrawerLayoutProps> = (props) => {
-    const { children, drawer, layoutID, classes, ...otherDivProps } = props;
+    const { children, drawer, classes, ...otherDivProps } = props;
     const theme = useTheme();
     const [padding, setPadding] = useState(0);
     const defaultClasses = useStyles();
@@ -49,8 +47,8 @@ export const DrawerLayout: React.FC<DrawerLayoutProps> = (props) => {
     return (
         <DrawerLayoutContext.Provider
             value={{
-                onPaddingChange: (id: number | string, width: number): void => {
-                    if (id === layoutID) setPadding(width);
+                onPaddingChange: (width: number): void => {
+                    setPadding(width);
                 },
             }}
         >

--- a/components/src/core/DrawerLayout/contexts/DrawerLayoutContextProvider.tsx
+++ b/components/src/core/DrawerLayout/contexts/DrawerLayoutContextProvider.tsx
@@ -1,12 +1,12 @@
 import { createContext, useContext } from 'react';
 
 type DrawerLayoutContextType = {
-    onPaddingChange: (id: number | string, padding: number) => void;
+    onPaddingChange: (padding: number) => void;
 };
 
 export const DrawerLayoutContext = createContext<DrawerLayoutContextType | null>({
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    onPaddingChange: (id: number | string, padding: number) => null,
+    onPaddingChange: (padding: number) => null,
 });
 
 export const useDrawerLayout = (): DrawerLayoutContextType => {

--- a/components/src/core/DrawerLayout/contexts/DrawerLayoutContextProvider.tsx
+++ b/components/src/core/DrawerLayout/contexts/DrawerLayoutContextProvider.tsx
@@ -1,17 +1,15 @@
-import { Ref, createContext, useContext } from 'react';
+import { createContext, useContext } from 'react';
 
 type DrawerLayoutContextType = {
-    id?: string | number;
-    padding: number;
     onPaddingChange: (id: number | string, padding: number) => void;
 };
 
-export const DrawerLayoutContext = createContext<DrawerLayoutContextType | null>(null);
+export const DrawerLayoutContext = createContext<DrawerLayoutContextType | null>({
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    onPaddingChange: (id: number | string, padding: number) => null,
+});
 
 export const useDrawerLayout = (): DrawerLayoutContextType => {
     const context = useContext(DrawerLayoutContext);
-    if (context === null) {
-        throw new Error('useSearch must be used within a DrawerLayoutContextProvider');
-    }
     return context;
 };

--- a/components/src/core/DrawerLayout/contexts/DrawerLayoutContextProvider.tsx
+++ b/components/src/core/DrawerLayout/contexts/DrawerLayoutContextProvider.tsx
@@ -1,0 +1,17 @@
+import { Ref, createContext, useContext } from 'react';
+
+type DrawerLayoutContextType = {
+    id?: string | number;
+    padding: number;
+    onPaddingChange: (id: number | string, padding: number) => void;
+};
+
+export const DrawerLayoutContext = createContext<DrawerLayoutContextType | null>(null);
+
+export const useDrawerLayout = (): DrawerLayoutContextType => {
+    const context = useContext(DrawerLayoutContext);
+    if (context === null) {
+        throw new Error('useSearch must be used within a DrawerLayoutContextProvider');
+    }
+    return context;
+};

--- a/docs/Drawer.md
+++ b/docs/Drawer.md
@@ -46,13 +46,14 @@ const xsDown = useMediaQuery(theme.breakpoints.down('xs'));
 
 <div style="overflow: auto;">
 
-| Prop Name                       | Description                                                | Type                                             | Required | Default |
-| ------------------------------- | ---------------------------------------------------------- | ------------------------------------------------ | -------- | ------- |
-| open                            | Controls the open/closed state of the drawer               | `boolean`                                        | yes      |         |
-| classes                         | Style overrides                                            | `DrawerClasses`                                  | no       |         |
-| variant                         | The variant to use (see below)                             | `'permanent'` \| `'persistent'` \| `'temporary'` | no       |         |
-| width                           | Sets the width of the drawer (in px) when open             | `number`                                         | no       |         |
-| [...sharedProps](#shared-props) | Props that can be set at any level in the drawer hierarchy | -                                                | no       |         |
+| Prop Name                       | Description                                                    | Type                                             | Required | Default |
+| ------------------------------- | -------------------------------------------------------------- | ------------------------------------------------ | -------- | ------- |
+| open                            | Controls the open/closed state of the drawer                   | `boolean`                                        | yes      |         |
+| classes                         | Style overrides                                                | `DrawerClasses`                                  | no       |         |
+| variant                         | The variant to use (see below)                                 | `'permanent'` \| `'persistent'` \| `'temporary'` | no       |         |
+| width                           | Sets the width of the drawer (in px) when open                 | `number`                                         | no       |         |
+| layoutID                        | Identifies the `<DrawerLayout/>` that this `<Drawer>` controls | `number` \| `string`                             | no       |         |
+| [...sharedProps](#shared-props) | Props that can be set at any level in the drawer hierarchy     | -                                                | no       |         |
 
 </div>
 
@@ -365,16 +366,20 @@ import { Drawer, DrawerLayout } from '@pxblue/react-components';
 
 <div style="overflow: auto;">
 
-| Prop Name | Description                     | Type                                 | Required | Default |
-| --------- | ------------------------------- | ------------------------------------ | -------- | ------- |
-| classes   | Style overrides                 | `DrawerLayoutClasses`                | no       |         |
-| drawer    | Drawer component to be embedded | `ReactElement<DrawerComponentProps>` | yes      |         |
+| Prop Name | Description                                               | Type                                 | Required | Default |
+| --------- | --------------------------------------------------------- | ------------------------------------ | -------- | ------- |
+| classes   | Style overrides                                           | `DrawerLayoutClasses`                | no       |         |
+| drawer    | Drawer component to be embedded                           | `ReactElement<DrawerComponentProps>` | yes      |         |
+| layoutID  | ID to link `<DrawerLayout/>` with a particular `<Drawer>` | `number` \| `string`                 | no       |         |
+
 
 </div>
 
 Any other props supplied will be provided to the root element (`div`).
 
 > **Note on Scrolling**: When using client-side routing in your application, you may notice that the window scroll position does not reset when navigating to new routes. To address this issue, you will need to manually update the scroll position when new pages are loaded. If you are using React Router they have [several examples](https://reacttraining.com/react-router/web/guides/scroll-restoration) on how to implement this in your application.
+
+> **Note on using multiple drawers**: If your application uses multiple `<Drawer>`s, each `<DrawerLayout>` will automatically adjust based on the state of the nearest `<Drawer>`. If you are using some `<Drawer>`s with a `<DrawerLayout>` and some without, you will need to use the `layoutID` properties to explicitly indicate which `<Drawer>` should control which `<DrawerLayout>` - otherwise both may inadvertently affect the styles of the `<DrawerLayout>`.
 
 #### Classes
 

--- a/docs/Drawer.md
+++ b/docs/Drawer.md
@@ -50,9 +50,9 @@ const xsDown = useMediaQuery(theme.breakpoints.down('xs'));
 | ------------------------------- | -------------------------------------------------------------- | ------------------------------------------------ | -------- | ------- |
 | open                            | Controls the open/closed state of the drawer                   | `boolean`                                        | yes      |         |
 | classes                         | Style overrides                                                | `DrawerClasses`                                  | no       |         |
+| noLayout                        | Set to true if used without a `<DrawerLayout>`                 | `boolean`                                        | no       | false   |
 | variant                         | The variant to use (see below)                                 | `'permanent'` \| `'persistent'` \| `'temporary'` | no       |         |
 | width                           | Sets the width of the drawer (in px) when open                 | `number`                                         | no       |         |
-| layoutID                        | Identifies the `<DrawerLayout/>` that this `<Drawer>` controls | `number` \| `string`                             | no       |         |
 | [...sharedProps](#shared-props) | Props that can be set at any level in the drawer hierarchy     | -                                                | no       |         |
 
 </div>
@@ -64,6 +64,8 @@ The `Drawer` has three `variant`s:
 -   **Permanent**: Always open, even when `open` is set to false.
 -   **Persistent**: When `open` is set to false, the `<Drawer>` collapses itself as a navigation rail, and hover will make it expand temporarily; when `open` is set to true, it behaves like a permanent `<Drawer>`.
 -   **Temporary**: When `open` is set to false, the `<Drawer>` is hidden; when `open` is set to true, it slides in.
+
+> **Note on using multiple drawers**: If your application uses multiple `<Drawer>`s, each `<DrawerLayout>` will automatically adjust based on the state of the nearest `<Drawer>`. If you are using a `<Drawer>` without a `<DrawerLayout>`, you should set the `noLayout` property to true on the `<Drawer>` to prevent inadvertently affecting the styles of any `<DrawerLayout>`s.
 
 #### Classes
 
@@ -370,16 +372,12 @@ import { Drawer, DrawerLayout } from '@pxblue/react-components';
 | --------- | --------------------------------------------------------- | ------------------------------------ | -------- | ------- |
 | classes   | Style overrides                                           | `DrawerLayoutClasses`                | no       |         |
 | drawer    | Drawer component to be embedded                           | `ReactElement<DrawerComponentProps>` | yes      |         |
-| layoutID  | ID to link `<DrawerLayout/>` with a particular `<Drawer>` | `number` \| `string`                 | no       |         |
-
 
 </div>
 
 Any other props supplied will be provided to the root element (`div`).
 
 > **Note on Scrolling**: When using client-side routing in your application, you may notice that the window scroll position does not reset when navigating to new routes. To address this issue, you will need to manually update the scroll position when new pages are loaded. If you are using React Router they have [several examples](https://reacttraining.com/react-router/web/guides/scroll-restoration) on how to implement this in your application.
-
-> **Note on using multiple drawers**: If your application uses multiple `<Drawer>`s, each `<DrawerLayout>` will automatically adjust based on the state of the nearest `<Drawer>`. If you are using some `<Drawer>`s with a `<DrawerLayout>` and some without, you will need to use the `layoutID` properties to explicitly indicate which `<Drawer>` should control which `<DrawerLayout>` - otherwise both may inadvertently affect the styles of the `<DrawerLayout>`.
 
 #### Classes
 


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
For PXBLUE-1456.
Fixes #41 

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
RefactorRefactor the Drawer/DrawerLayout to link them in the case when multiple drawers are used
- By default, a Drawer will be linked to it's closest DrawerLayout ancestor (without any changes in usage)
    - This also means that if you are using multiple DrawerLayouts with Drawers, they will work fine without any changes in usage (each Drawer will simply operate the DrawerLayout closest to it in the DOM tree)
- ~~The only case where you need to use the `layoutID` prop on Drawer and DrawerLayout is if you have some Drawers inside a DrawerLayout and some without. In order to prevent the rogue drawer from affecting the nearest DrawerLayout, you'll need to give the other ones the ID.~~
- The only case where a use needs to change anything is if they are using multiple Drawers and some of them are inside of a DrawerLayout and some are not. In this case, they will need to identify the Drawers that are not part of a DrawerLayout by adding the `noLayout` prop.
    - This is a very very small use-case, 99% of the time nobody is going to run into this, so they'll be able to continue using the Drawer/DrawerLayout as before without needing to make any changes.
- Updated documentation

The following should all work as expected:
```
<DrawerLayout drawer={<Drawer />} />
```
```
<DrawerLayout drawer={<Drawer />} />
...
<DrawerLayout drawer={<Drawer />} />
```
```
<Drawer />
```
```
<DrawerLayout drawer={<Drawer />}>
    <Drawer noLayout/>
</DrawerLayout>
```