### PR TITLE
 Relocate appliedTheme to welcome story, update storybook-dark-mode d…

### DIFF
--- a/demos/storybook/.storybook/config.js
+++ b/demos/storybook/.storybook/config.js
@@ -1,19 +1,16 @@
 import React from 'react';
 import { addDecorator, addParameters } from '@storybook/react';
 import { withKnobs } from '@storybook/addon-knobs';
-import { MuiThemeProvider, createMuiTheme } from '@material-ui/core/styles';
-import { blue as ReactTheme } from '@pxblue/react-themes';
-import { blueDark as ReactThemeDark } from '@pxblue/react-themes';
+import { createMuiTheme, jssPreset, MuiThemeProvider, StylesProvider } from '@material-ui/core/styles';
+import { blue as ReactTheme, blueDark as ReactThemeDark } from '@pxblue/react-themes';
 import 'typeface-open-sans';
 import { pxblueTheme } from '@pxblue/storybook-themes';
-import { useDarkMode } from 'storybook-dark-mode';
 import { CssBaseline } from '@material-ui/core';
-import { StylesProvider, jssPreset } from '@material-ui/core/styles';
 import { create } from 'jss';
 import rtl from 'jss-rtl';
-import { useEffect, useState } from '@storybook/addons';
-import addons from '@storybook/addons';
+import addons, { useEffect, useState } from '@storybook/addons';
 import { DIR_CHANGE_EVENT, getDirection } from '@pxblue/storybook-rtl-addon';
+import { useDarkMode } from 'storybook-dark-mode/dist';
 
 const channel = addons.getChannel();
 
@@ -52,6 +49,7 @@ if (window.top.location.hostname === 'localhost') {
     pxblueTheme.brandImage = require('../assets/pxblue-react.svg');
 }
 
+// Only set theme inside storybook canvas.
 const themeInit = { dark: pxblueTheme, light: pxblueTheme, current: 'light' };
 window.localStorage.setItem('sb-addon-themes-3', JSON.stringify(themeInit));
 
@@ -74,9 +72,6 @@ addParameters({
         dark: { ...pxblueTheme },
     },
 });
-
-// Refactor welcome story to just createMuiTheme directly.
-export const appliedTheme = createMuiTheme(ReactTheme);
 
 // Configure JSS
 const jss = create({ plugins: [...jssPreset().plugins, rtl()] });

--- a/demos/storybook/package.json
+++ b/demos/storybook/package.json
@@ -71,7 +71,7 @@
         "mini-css-extract-plugin": "^0.7.0",
         "prettier": "^1.19.1",
         "sass-loader": "^8.0.2",
-        "storybook-dark-mode": "^0.4.0",
+        "storybook-dark-mode": "^0.6.1",
         "ts-loader": "^6.2.2",
         "typeface-open-sans": "0.0.75"
     }

--- a/demos/storybook/stories/welcome.stories.tsx
+++ b/demos/storybook/stories/welcome.stories.tsx
@@ -1,19 +1,23 @@
 import { Button, createStyles, makeStyles, Typography } from '@material-ui/core';
 import { storiesOf } from '@storybook/react';
 import React from 'react';
-import { appliedTheme } from '../.storybook/config';
+import { blue as ReactTheme } from '@pxblue/react-themes';
 import { hideTopBanner, storyWrapper } from '../src/utils';
 import * as Colors from '@pxblue/colors';
+import { createMuiTheme } from '@material-ui/core/styles';
 const backgroundImage = require('../assets/circles-bg.svg');
 const packageJSON = require('@pxblue/react-components/package.json');
 
 export const stories = storiesOf('Intro/Overview', module);
 
+// Refactor welcome story to just createMuiTheme directly.
+export const lightTheme = createMuiTheme(ReactTheme);
+
 const useStyles = makeStyles(() =>
     createStyles({
         root: {
-            color: appliedTheme.palette.primary.contrastText,
-            backgroundColor: appliedTheme.palette.primary.main,
+            color: lightTheme.palette.primary.contrastText,
+            backgroundColor: lightTheme.palette.primary.main,
             backgroundImage: `url(${backgroundImage})`,
             backgroundSize: '200%',
             height: '100%',

--- a/demos/storybook/yarn.lock
+++ b/demos/storybook/yarn.lock
@@ -12570,10 +12570,10 @@ store2@^2.7.1:
   resolved "https://registry.yarnpkg.com/store2/-/store2-2.11.2.tgz#a298e5e97b21b3ce7419b732540bc7c79cb007db"
   integrity sha512-TQMKs+C6n9idtzLpxluikmDCYiDJrTbbIGn9LFxMg0BVTu+8JZKSlXTWYRpOFKlfKD5HlDWLVpJJyNGZ2e9l1A==
 
-storybook-dark-mode@^0.4.0:
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/storybook-dark-mode/-/storybook-dark-mode-0.4.1.tgz#8bd4aa12f5fa9691ae9b422be76cc2095b432329"
-  integrity sha512-QGH6/eOmqXZFOGWA/2tLD1verRCcfmIgxxmK2kwIyfVXGFdGA3DCQttqWCCfm/4MwJeOR+6NqtPeN8GEqg9+oQ==
+storybook-dark-mode@^0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/storybook-dark-mode/-/storybook-dark-mode-0.6.1.tgz#0527567ac5853c49f6f7a6f68f792fe9322c5a5a"
+  integrity sha512-E8LIHnVfFhOsPqBc2fLshVBnspziYMXHdwQc/qAjpf4h5ewzrDzeqy4QfJioE+jDoyyZXEtIMugzb0wIaK10Uw==
   dependencies:
     fast-deep-equal "^3.0.0"
     memoizerific "^1.11.3"


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes #170 

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Update dependency to fix dark mode flashing
- Explicitly only use lightTheme on the welcome page. 

This issue was fixed here already, we just needed to update:
https://github.com/hipstersmoothie/storybook-dark-mode/issues/109

<!-- Include screenshots if they will help illustrate the changes in this PR -->
Firebase deployment for quick testing: https://pxblue-react-library.web.app/

