### PR TITLE
Add optional divider prop to DrawerHeader, default false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fixes RTL support issues in the `<DrawerLayout>`/`<Drawer>`
 - Fixes an issue with text wrapping in the `<InfoListItem>` subtitle
 - Fixes an issue with hover color alpha channel in `<InfoListItem>`
+- Adds optional prop to the `<DrawerHeader>` to add a bottom divider
 
 ## V4.0.2
 

--- a/components/src/core/Drawer/DrawerHeader.tsx
+++ b/components/src/core/Drawer/DrawerHeader.tsx
@@ -22,6 +22,7 @@ export type DrawerHeaderProps = ToolbarProps & {
     backgroundImage?: string;
     backgroundOpacity?: number;
     classes?: DrawerHeaderClasses;
+    divider?: boolean;
     fontColor?: string;
     icon?: ReactNode;
     onIconClick?: () => void;
@@ -99,6 +100,7 @@ export const DrawerHeader: React.FC<DrawerHeaderProps> = (props) => {
     const {
         backgroundImage,
         classes,
+        divider,
         icon,
         onIconClick,
         subtitle,
@@ -172,7 +174,7 @@ export const DrawerHeader: React.FC<DrawerHeaderProps> = (props) => {
                 )}
                 {getHeaderContent()}
             </Toolbar>
-            <Divider />
+            {divider && <Divider />}
         </>
     );
 };
@@ -180,6 +182,7 @@ DrawerHeader.displayName = 'DrawerHeader';
 DrawerHeader.defaultProps = {
     backgroundOpacity: 0.3,
     classes: {},
+    divider: false,
 };
 DrawerHeader.propTypes = {
     backgroundColor: PropTypes.string,
@@ -194,6 +197,7 @@ DrawerHeader.propTypes = {
         subtitle: PropTypes.string,
         title: PropTypes.string,
     }),
+    divider: PropTypes.bool,
     fontColor: PropTypes.string,
     icon: PropTypes.element,
     onIconClick: PropTypes.func,

--- a/demos/storybook/stories/drawer/with-full-config.tsx
+++ b/demos/storybook/stories/drawer/with-full-config.tsx
@@ -129,6 +129,7 @@ export const withFullConfig = (context: DrawerStoryContext): StoryFnReactReturnT
             headerBackgroundImageOptions[
                 select('backgroundImage', ['undefined', 'Pattern', 'Farm'], 'Pattern', headerGroupId)
             ],
+        divider: boolean('divider', false, headerGroupId),
         backgroundOpacity: number('backgroundOpacity', 0.4, { range: true, min: 0, max: 1, step: 0.1 }, headerGroupId),
         fontColor: color('fontColor', Colors.white[50], headerGroupId),
         icon: getIcon(select('icon', ['<Menu />', '<FitnessCenter />', 'undefined'], '<Menu />', headerGroupId)),
@@ -305,6 +306,7 @@ export const withFullConfig = (context: DrawerStoryContext): StoryFnReactReturnT
                 backgroundColor={headerKnobs.backgroundColor}
                 backgroundImage={headerKnobs.backgroundImage}
                 backgroundOpacity={headerKnobs.backgroundOpacity}
+                divider={headerKnobs.divider}
                 fontColor={headerKnobs.fontColor}
                 icon={headerKnobs.icon}
                 subtitle={headerKnobs.subtitle}

--- a/docs/Drawer.md
+++ b/docs/Drawer.md
@@ -95,6 +95,7 @@ The `<DrawerHeader>` contains the content at the top of the `<Drawer>`. By defau
 | backgroundImage   | An image to display in the header              | `string`              | no       |                              |
 | backgroundOpacity | The opacity of the background image            | `number`              | no       | `0.3`                        |
 | classes           | Style overrides                                | `DrawerHeaderClasses` | no       |                              |
+| divider           | Optional divider which appears beneath header  | `boolean`             | no       | `false`                      |
 | fontColor         | The color of the text elements                 | `string`              | no       | dynamic based on background  |
 | icon              | A component to render for the icon             | `ReactNode`           | no       |                              |
 | onIconClick       | A function to execute when the icon is clicked | `function`            | no       | `() => {}`                   |


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes #164 

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Divider under DrawerHeader is now optional and by default turned off.
