### PR TITLE
Use computed style to unit test component styles

### DIFF
--- a/components/src/core/InfoListItem/InfoListItem.test.tsx
+++ b/components/src/core/InfoListItem/InfoListItem.test.tsx
@@ -4,9 +4,13 @@ import { Mount, Shallow } from '../types';
 import { InfoListItem } from './InfoListItem';
 import Enzyme from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
+import { findByTestId, getComputedStyleFromHTMLString } from '../test-utils';
+import * as Colors from '@pxblue/colors';
+import color from 'color';
 
 import Chevron from '@material-ui/icons/ChevronRight';
 import PersonIcon from '@material-ui/icons/Person';
+import { Avatar } from '@material-ui/core';
 
 import { createMount, createShallow } from '@material-ui/core/test-utils';
 
@@ -37,27 +41,49 @@ describe('InfoListItem', () => {
         wrapper = shallow(<InfoListItem hidePadding title="Test" />);
         expect(wrapper.find(PersonIcon).length).toEqual(0);
     });
-    /* No longer using in-line props to modify styling.
-    TODO: Update this test to work.
+
     it('renders correct icon Color', () => {
-        let wrapper = shallow(<InfoListItem icon={<PersonIcon />} title="Test" />);
-        expect(wrapper.find(ListItemIcon)).toEqual('inherit');
-
-        wrapper = shallow(<InfoListItem title="Test" icon={<PersonIcon />} statusColor={'red'} />);
-        expect(wrapper.find(ListItemIcon).props().style.color).toEqual('red');
-
-        wrapper = shallow(<InfoListItem title="Test" icon={<PersonIcon />} statusColor={'red'} iconColor={'green'} />);
-        expect(wrapper.find(ListItemIcon).props().style.color).toEqual('green');
-
-        wrapper = shallow(<InfoListItem title="Test" icon={<PersonIcon />} statusColor={'red'} avatar />);
-        expect(wrapper.find(Avatar).props().style.color).toEqual(Colors.white['50']);
+        let wrapper = shallow(<InfoListItem title={'Test'} icon={<PersonIcon />} statusColor={'red'} />);
+        let testedStyle = getComputedStyleFromHTMLString(wrapper.find(Avatar).html());
+        // TODO: make this test work.
+        // The testedStyle outputs "icon-avatar" has background-color: rgb(189, 189, 189), and color
+        // is rgb(250, 250, 250)
+        // expect(testedStyle.color).toEqual(
+        //     color('red')
+        //         .rgb()
+        //         .string()
+        // );
+        testedStyle = getComputedStyleFromHTMLString(findByTestId('status-stripe', wrapper).html());
+        expect(testedStyle.backgroundColor).toEqual('red');
 
         wrapper = shallow(
-            <InfoListItem title="Test" icon={<PersonIcon />} statusColor={'red'} iconColor={'blue'} avatar />
+            <InfoListItem title={'Test'} icon={<PersonIcon />} statusColor={'red'} iconColor={'green'} />
         );
-        expect(wrapper.find(Avatar).props().style.color).toEqual('blue');
+        testedStyle = getComputedStyleFromHTMLString(wrapper.find(Avatar).html());
+        expect(testedStyle.color).toEqual('green');
+        testedStyle = getComputedStyleFromHTMLString(findByTestId('status-stripe', wrapper).html());
+        expect(testedStyle.backgroundColor).toEqual('red');
+
+        wrapper = shallow(<InfoListItem title={'Test'} icon={<PersonIcon />} statusColor={'red'} avatar />);
+        testedStyle = getComputedStyleFromHTMLString(wrapper.find(Avatar).html());
+        expect(testedStyle.color).toEqual(
+            color(Colors.white['50'])
+                .rgb()
+                .string()
+        );
+        expect(testedStyle.backgroundColor).toEqual('red');
+        testedStyle = getComputedStyleFromHTMLString(findByTestId('status-stripe', wrapper).html());
+        expect(testedStyle.backgroundColor).toEqual('red');
+
+        wrapper = shallow(
+            <InfoListItem title={'Test'} icon={<PersonIcon />} statusColor={'red'} iconColor={'blue'} avatar />
+        );
+        testedStyle = getComputedStyleFromHTMLString(wrapper.find(Avatar).html());
+        expect(testedStyle.color).toEqual('blue');
+        expect(testedStyle.backgroundColor).toEqual('red');
+        testedStyle = getComputedStyleFromHTMLString(findByTestId('status-stripe', wrapper).html());
+        expect(testedStyle.backgroundColor).toEqual('red');
     });
- */
 
     it('renders rightComponent', () => {
         let wrapper = shallow(<InfoListItem title="Test" chevron />);

--- a/components/src/core/InfoListItem/InfoListItem.tsx
+++ b/components/src/core/InfoListItem/InfoListItem.tsx
@@ -73,7 +73,9 @@ export const InfoListItem: React.FC<InfoListItemProps> = (props) => {
         if (icon) {
             return (
                 <ListItemAvatar>
-                    <Avatar className={combine(avatar ? 'avatar' : 'icon')}>{icon}</Avatar>
+                    <Avatar className={combine(avatar ? 'avatar' : 'icon')} data-test={'icon-avatar'}>
+                        {icon}
+                    </Avatar>
                 </ListItemAvatar>
             );
         } else if (!hidePadding) {
@@ -142,7 +144,7 @@ export const InfoListItem: React.FC<InfoListItemProps> = (props) => {
     return (
         // @ts-ignore
         <ListItem button={hasRipple} className={combine('root')} {...otherListItemProps}>
-            <div className={combine('statusStripe')} />
+            <div className={combine('statusStripe')} data-test={'status-stripe'} />
             {divider && <Divider className={combine('divider')} />}
             {(icon || !hidePadding) && getIcon()}
             {leftComponent}

--- a/components/src/core/ListItemTag/ListItemTag.test.tsx
+++ b/components/src/core/ListItemTag/ListItemTag.test.tsx
@@ -2,9 +2,11 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import { Shallow } from '../types';
 import { ListItemTag } from './ListItemTag';
-import { findByTestId } from '../test-utils';
+import { findByTestId, getComputedStyleFromHTMLString } from '../test-utils';
 import Enzyme from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
+import * as Colors from '@pxblue/colors';
+import color from 'color';
 
 import { createShallow } from '@material-ui/core/test-utils';
 
@@ -33,15 +35,21 @@ describe('ListItemTag', () => {
         expect(wrapper.text()).toEqual('test');
     });
 
-    /*
-    This won't work if we use JSS to style the component
-
     it('renders with correct colors', () => {
-        const wrapper = shallow(
-            <ListItemTag label={'test'} fontColor={Colors.gold['200']} backgroundColor={Colors.green['900']} />
+        const fontColor = Colors.gold[200];
+        const backgroundColor = Colors.green[900];
+        const wrapper = shallow(<ListItemTag label={'test'} fontColor={fontColor} backgroundColor={backgroundColor} />);
+        const computedStyle = getComputedStyleFromHTMLString(wrapper.html());
+
+        expect(computedStyle.color).toEqual(
+            color(fontColor)
+                .rgb()
+                .string()
         );
-        expect(wrapper.props().style.color).toEqual(Colors.gold['200']);
-        expect(wrapper.props().style.backgroundColor).toEqual(Colors.green['900']);
+        expect(computedStyle.backgroundColor).toEqual(
+            color(backgroundColor)
+                .rgb()
+                .string()
+        );
     });
-    */
 });

--- a/components/src/core/ScoreCard/ScoreCard.test.tsx
+++ b/components/src/core/ScoreCard/ScoreCard.test.tsx
@@ -2,15 +2,16 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 
 import { Divider, List, Typography } from '@material-ui/core';
-
+import * as Colors from '@pxblue/colors';
 import { createMount, createShallow } from '@material-ui/core/test-utils';
 import { MoreVert } from '@material-ui/icons';
 import Enzyme from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import { HeroBanner } from '../HeroBanner';
-import { findByTestId } from '../test-utils';
+import { findByTestId, getComputedStyleFromHTMLString } from '../test-utils';
 import { Mount, Shallow } from '../types';
 import { ScoreCard } from './ScoreCard';
+import color from 'color';
 
 Enzyme.configure({ adapter: new Adapter() });
 let mount: Mount;
@@ -55,20 +56,21 @@ describe('ScoreCard', () => {
         expect(findByTestId('action-item', wrapper).length).toEqual(2);
         expect(wrapper.find(MoreVert).length).toEqual(2);
     });
-    /* This won't work if we use JSS to style the component
     it('renders correct header text color', () => {
         let wrapper = shallow(<ScoreCard headerTitle={'Test'} />);
-        let title = wrapper.find(Typography);
+        let testedStyle = getComputedStyleFromHTMLString(findByTestId('header', wrapper).html());
+        expect(testedStyle.color).toEqual(
+            color(Colors.white['50'])
+                .rgb()
+                .string()
+        );
 
-        let div = findByTestId('header', wrapper);
-        expect(div.props().style.color).toEqual(Colors.white[50]); 
         wrapper = shallow(<ScoreCard headerTitle={'Test'} headerFontColor={'red'} />);
-        title = wrapper.find(Typography);
-        div = findByTestId('header', wrapper);
-        expect(title.props().style.color).toEqual('red');
-        expect(div.props().style.color).toEqual('red');
+        testedStyle = getComputedStyleFromHTMLString(wrapper.find(Typography).html());
+        expect(testedStyle.color).toEqual('red');
+        testedStyle = getComputedStyleFromHTMLString(findByTestId('header', wrapper).html());
+        expect(testedStyle.color).toEqual('red');
     });
-    */
     it('renders body content', () => {
         let wrapper = shallow(<ScoreCard headerTitle={'Test'} />);
         let content = findByTestId('content', wrapper);

--- a/components/src/core/test-utils.tsx
+++ b/components/src/core/test-utils.tsx
@@ -2,3 +2,10 @@ import { ShallowWrapper, ReactWrapper } from 'enzyme';
 
 export const findByTestId = (id: string, wrapper: ShallowWrapper | ReactWrapper): any =>
     wrapper.find(`[data-test="${id}"]`);
+
+// https://stackoverflow.com/a/494348
+export const getComputedStyleFromHTMLString = (str: string): CSSStyleDeclaration => {
+    const wrapperDiv = document.createElement('div');
+    wrapperDiv.innerHTML = str;
+    return window.getComputedStyle(wrapperDiv.firstElementChild);
+};


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes #70, fixes #119 

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Use the majestic `window.getComputedStyles` to unit test for info list item, score card and list item tag.

#### Need help on
in components/src/core/InfoListItem/InfoListItem.test.tsx, there is a comment out test case. Would like another person to take a look at why that is. It should look like this: 

![image](https://user-images.githubusercontent.com/8997218/90834766-fce7ee80-e318-11ea-83ca-2bc38b6572d6.png)
