### PR TITLE
Fix icons that should not be flipped

### DIFF
--- a/demos/storybook/src/utils.tsx
+++ b/demos/storybook/src/utils.tsx
@@ -1,6 +1,7 @@
 import { StoryFnReactReturnType } from '@storybook/react/dist/client/preview/types';
 import React from 'react';
 import { COMPONENT_SECTION_NAME, README_STORY_NAME } from './constants';
+import { getDirection } from '@pxblue/storybook-rtl-addon';
 
 let banner: HTMLElement;
 
@@ -95,3 +96,6 @@ export const getReadMe = (name: string): any => {
     });
     return md;
 };
+
+export const getLeftToRightIconTransform = (): any =>
+    getDirection() === 'rtl' ? { transform: 'scaleX(-1)' } : undefined;

--- a/demos/storybook/stories/channel-value/with-fontSize.tsx
+++ b/demos/storybook/stories/channel-value/with-fontSize.tsx
@@ -3,19 +3,14 @@ import * as Colors from '@pxblue/colors';
 import { ChannelValue } from '@pxblue/react-components';
 import { number } from '@storybook/addon-knobs';
 import { StoryFnReactReturnType } from '@storybook/react/dist/client/preview/types';
-import { getDirection } from '@pxblue/storybook-rtl-addon';
+import { getLeftToRightIconTransform } from '../../src/utils';
 import React from 'react';
 
 export const withFontSize = (): StoryFnReactReturnType => (
     <ChannelValue
         value={'123'}
         units={'hz'}
-        icon={
-            <Trend
-                htmlColor={Colors.red[500]}
-                style={{ transform: getDirection() === 'rtl' ? 'scaleX(-1)' : undefined }}
-            />
-        }
+        icon={<Trend htmlColor={Colors.red[500]} style={getLeftToRightIconTransform()} />}
         fontSize={number('fontSize', 30)}
     />
 );

--- a/demos/storybook/stories/channel-value/with-fontSize.tsx
+++ b/demos/storybook/stories/channel-value/with-fontSize.tsx
@@ -3,13 +3,19 @@ import * as Colors from '@pxblue/colors';
 import { ChannelValue } from '@pxblue/react-components';
 import { number } from '@storybook/addon-knobs';
 import { StoryFnReactReturnType } from '@storybook/react/dist/client/preview/types';
+import { getDirection } from '@pxblue/storybook-rtl-addon';
 import React from 'react';
 
 export const withFontSize = (): StoryFnReactReturnType => (
     <ChannelValue
         value={'123'}
         units={'hz'}
-        icon={<Trend htmlColor={Colors.red[500]} />}
+        icon={
+            <Trend
+                htmlColor={Colors.red[500]}
+                style={{ transform: getDirection() === 'rtl' ? 'scaleX(-1)' : undefined }}
+            />
+        }
         fontSize={number('fontSize', 30)}
     />
 );

--- a/demos/storybook/stories/channel-value/with-full-config.tsx
+++ b/demos/storybook/stories/channel-value/with-full-config.tsx
@@ -5,7 +5,7 @@ import { ChannelValue } from '@pxblue/react-components';
 import { WITH_FULL_CONFIG_STORY_NAME } from '../../src/constants';
 import { StoryFnReactReturnType } from '@storybook/react/dist/client/preview/types';
 import { boolean, color, number, text } from '@storybook/addon-knobs';
-import { getDirection } from '@pxblue/storybook-rtl-addon';
+import { getLeftToRightIconTransform } from '../../src/utils';
 
 export const withFullConfig = (): StoryFnReactReturnType => {
     const value = text('value', '123');
@@ -13,7 +13,7 @@ export const withFullConfig = (): StoryFnReactReturnType => {
     const textColor = color('color', Colors.red[500]);
     const iconColor = color('icon.htmlColor', Colors.black[500]);
     const icon = boolean('Show Icon', true) ? (
-        <Trend htmlColor={iconColor} style={{ transform: getDirection() === 'rtl' ? 'scaleX(-1)' : undefined }} />
+        <Trend htmlColor={iconColor} style={getLeftToRightIconTransform()} />
     ) : (
         undefined
     );

--- a/demos/storybook/stories/channel-value/with-full-config.tsx
+++ b/demos/storybook/stories/channel-value/with-full-config.tsx
@@ -1,17 +1,22 @@
+import React from 'react';
 import Trend from '@material-ui/icons/TrendingUp';
 import * as Colors from '@pxblue/colors';
 import { ChannelValue } from '@pxblue/react-components';
-import { boolean, color, number, text } from '@storybook/addon-knobs';
-import { StoryFnReactReturnType } from '@storybook/react/dist/client/preview/types';
-import React from 'react';
 import { WITH_FULL_CONFIG_STORY_NAME } from '../../src/constants';
+import { StoryFnReactReturnType } from '@storybook/react/dist/client/preview/types';
+import { boolean, color, number, text } from '@storybook/addon-knobs';
+import { getDirection } from '@pxblue/storybook-rtl-addon';
 
 export const withFullConfig = (): StoryFnReactReturnType => {
     const value = text('value', '123');
     const units = text('units', 'hz');
     const textColor = color('color', Colors.red[500]);
     const iconColor = color('icon.htmlColor', Colors.black[500]);
-    const icon = boolean('Show Icon', true) ? <Trend htmlColor={iconColor} /> : undefined;
+    const icon = boolean('Show Icon', true) ? (
+        <Trend htmlColor={iconColor} style={{ transform: getDirection() === 'rtl' ? 'scaleX(-1)' : undefined }} />
+    ) : (
+        undefined
+    );
     const fontSize = number('fontSize', 30);
     const prefix = boolean('prefix', false);
 

--- a/demos/storybook/stories/channel-value/with-icon.tsx
+++ b/demos/storybook/stories/channel-value/with-icon.tsx
@@ -3,19 +3,14 @@ import * as Colors from '@pxblue/colors';
 import { ChannelValue } from '@pxblue/react-components';
 import { color } from '@storybook/addon-knobs';
 import { StoryFnReactReturnType } from '@storybook/react/dist/client/preview/types';
-import { getDirection } from '@pxblue/storybook-rtl-addon';
+import { getLeftToRightIconTransform } from '../../src/utils';
 import React from 'react';
 
 export const withIcon = (): StoryFnReactReturnType => (
     <ChannelValue
         value={'123'}
         units={'hz'}
-        icon={
-            <Trend
-                htmlColor={color('icon.htmlColor', Colors.red[500])}
-                style={{ transform: getDirection() === 'rtl' ? 'scaleX(-1)' : undefined }}
-            />
-        }
+        icon={<Trend htmlColor={color('icon.htmlColor', Colors.red[500])} style={getLeftToRightIconTransform()} />}
     />
 );
 

--- a/demos/storybook/stories/channel-value/with-icon.tsx
+++ b/demos/storybook/stories/channel-value/with-icon.tsx
@@ -3,10 +3,20 @@ import * as Colors from '@pxblue/colors';
 import { ChannelValue } from '@pxblue/react-components';
 import { color } from '@storybook/addon-knobs';
 import { StoryFnReactReturnType } from '@storybook/react/dist/client/preview/types';
+import { getDirection } from '@pxblue/storybook-rtl-addon';
 import React from 'react';
 
 export const withIcon = (): StoryFnReactReturnType => (
-    <ChannelValue value={'123'} units={'hz'} icon={<Trend htmlColor={color('icon.htmlColor', Colors.red[500])} />} />
+    <ChannelValue
+        value={'123'}
+        units={'hz'}
+        icon={
+            <Trend
+                htmlColor={color('icon.htmlColor', Colors.red[500])}
+                style={{ transform: getDirection() === 'rtl' ? 'scaleX(-1)' : undefined }}
+            />
+        }
+    />
 );
 
 withIcon.story = { name: 'with icon' };

--- a/demos/storybook/stories/drawer/with-basic-config.tsx
+++ b/demos/storybook/stories/drawer/with-basic-config.tsx
@@ -1,4 +1,4 @@
-import { Accessibility, Menu, NotificationsActive, PermIdentity, Today, Dashboard, Toc } from '@material-ui/icons';
+import { Accessibility, Menu, NotificationsActive, Person, Today, Dashboard, LocalLibrary } from '@material-ui/icons';
 import { Drawer, DrawerBody, DrawerHeader, DrawerNavGroup, NavItem } from '@pxblue/react-components';
 import { boolean, text } from '@storybook/addon-knobs';
 import { StoryFnReactReturnType } from '@storybook/react/dist/client/preview/types';
@@ -10,7 +10,7 @@ export const navGroupItems1: NavItem[] = [
     {
         title: 'Identity Management',
         itemID: '1',
-        icon: <PermIdentity />,
+        icon: <Person />,
     },
     {
         title: 'Calendar',
@@ -36,9 +36,9 @@ export const navGroupItems2: NavItem[] = [
         icon: <Dashboard />,
     },
     {
-        title: 'Timeline',
+        title: 'Manuals',
         itemID: '2-2',
-        icon: <Toc />,
+        icon: <LocalLibrary />,
     },
 ];
 

--- a/demos/storybook/stories/drawer/with-full-config.tsx
+++ b/demos/storybook/stories/drawer/with-full-config.tsx
@@ -28,6 +28,7 @@ import {
     DrawerNavGroupProps,
     NavItem,
 } from '@pxblue/react-components';
+import { getDirection } from '@pxblue/storybook-rtl-addon';
 import { boolean, color, number, select, text } from '@storybook/addon-knobs';
 import { StoryFnReactReturnType } from '@storybook/react/dist/client/preview/types';
 import React from 'react';
@@ -80,6 +81,8 @@ const headerBackgroundImageOptions = {
     Farm: farmBgImage,
     undefined: undefined,
 };
+
+const getLeftToRightIconDirection = () => (getDirection() === 'rtl' ? { transform: 'scaleX(-1)' } : undefined);
 
 export const withFullConfig = (context: DrawerStoryContext): StoryFnReactReturnType => {
     // storybook tab names
@@ -218,7 +221,7 @@ export const withFullConfig = (context: DrawerStoryContext): StoryFnReactReturnT
             onClick: (): void => {
                 context.store.set({ selected: schedule });
             },
-            icon: <AirportShuttle />,
+            icon: <AirportShuttle style={getLeftToRightIconDirection()} />,
         },
     ];
 
@@ -238,7 +241,7 @@ export const withFullConfig = (context: DrawerStoryContext): StoryFnReactReturnT
             onClick: (): void => {
                 context.store.set({ selected: agreement });
             },
-            icon: <SendIcon />,
+            icon: <SendIcon style={getLeftToRightIconDirection()} />,
         },
         {
             title: accessibility,

--- a/demos/storybook/stories/drawer/with-full-config.tsx
+++ b/demos/storybook/stories/drawer/with-full-config.tsx
@@ -82,7 +82,8 @@ const headerBackgroundImageOptions = {
     undefined: undefined,
 };
 
-const getLeftToRightIconDirection = () => (getDirection() === 'rtl' ? { transform: 'scaleX(-1)' } : undefined);
+const getLeftToRightIconDirection = (): {} | undefined =>
+    getDirection() === 'rtl' ? { transform: 'scaleX(-1)' } : undefined;
 
 export const withFullConfig = (context: DrawerStoryContext): StoryFnReactReturnType => {
     // storybook tab names

--- a/demos/storybook/stories/drawer/with-full-config.tsx
+++ b/demos/storybook/stories/drawer/with-full-config.tsx
@@ -82,8 +82,7 @@ const headerBackgroundImageOptions = {
     undefined: undefined,
 };
 
-const getLeftToRightIconDirection = (): {} | undefined =>
-    getDirection() === 'rtl' ? { transform: 'scaleX(-1)' } : undefined;
+const getLeftToRightIconDirection = (): any => (getDirection() === 'rtl' ? { transform: 'scaleX(-1)' } : undefined);
 
 export const withFullConfig = (context: DrawerStoryContext): StoryFnReactReturnType => {
     // storybook tab names

--- a/demos/storybook/stories/drawer/with-full-config.tsx
+++ b/demos/storybook/stories/drawer/with-full-config.tsx
@@ -28,11 +28,11 @@ import {
     DrawerNavGroupProps,
     NavItem,
 } from '@pxblue/react-components';
-import { getDirection } from '@pxblue/storybook-rtl-addon';
 import { boolean, color, number, select, text } from '@storybook/addon-knobs';
 import { StoryFnReactReturnType } from '@storybook/react/dist/client/preview/types';
 import React from 'react';
 import { WITH_FULL_CONFIG_STORY_NAME } from '../../src/constants';
+import { getLeftToRightIconTransform } from '../../src/utils';
 import { DrawerStoryContext } from './util';
 
 const EatonLogo = require('../../assets/EatonLogo.svg');
@@ -81,8 +81,6 @@ const headerBackgroundImageOptions = {
     Farm: farmBgImage,
     undefined: undefined,
 };
-
-const getLeftToRightIconDirection = (): any => (getDirection() === 'rtl' ? { transform: 'scaleX(-1)' } : undefined);
 
 export const withFullConfig = (context: DrawerStoryContext): StoryFnReactReturnType => {
     // storybook tab names
@@ -221,7 +219,7 @@ export const withFullConfig = (context: DrawerStoryContext): StoryFnReactReturnT
             onClick: (): void => {
                 context.store.set({ selected: schedule });
             },
-            icon: <AirportShuttle style={getLeftToRightIconDirection()} />,
+            icon: <AirportShuttle style={getLeftToRightIconTransform()} />,
         },
     ];
 
@@ -241,7 +239,7 @@ export const withFullConfig = (context: DrawerStoryContext): StoryFnReactReturnT
             onClick: (): void => {
                 context.store.set({ selected: agreement });
             },
-            icon: <SendIcon style={getLeftToRightIconDirection()} />,
+            icon: <SendIcon style={getLeftToRightIconTransform()} />,
         },
         {
             title: accessibility,

--- a/demos/storybook/stories/empty-state/with-basic-usage.tsx
+++ b/demos/storybook/stories/empty-state/with-basic-usage.tsx
@@ -1,13 +1,19 @@
+import React from 'react';
 import { NotListedLocation } from '@material-ui/icons';
 import { EmptyState } from '@pxblue/react-components';
-import { text } from '@storybook/addon-knobs';
-import { StoryFnReactReturnType } from '@storybook/react/dist/client/preview/types';
-import React from 'react';
 import { WITH_MIN_PROPS_STORY_NAME } from '../../src/constants';
+import { StoryFnReactReturnType } from '@storybook/react/dist/client/preview/types';
+import { getDirection } from '@pxblue/storybook-rtl-addon';
+import { text } from '@storybook/addon-knobs';
 
 export const withBasicUsage = (): StoryFnReactReturnType => (
     <EmptyState
-        icon={<NotListedLocation fontSize={'inherit'} style={{ marginBottom: '0' }} />}
+        icon={
+            <NotListedLocation
+                fontSize={'inherit'}
+                style={{ transform: getDirection() === 'rtl' ? 'scaleX(-1)' : undefined }}
+            />
+        }
         title={text('title', 'Location Unknown')}
     />
 );

--- a/demos/storybook/stories/empty-state/with-basic-usage.tsx
+++ b/demos/storybook/stories/empty-state/with-basic-usage.tsx
@@ -3,17 +3,12 @@ import { NotListedLocation } from '@material-ui/icons';
 import { EmptyState } from '@pxblue/react-components';
 import { WITH_MIN_PROPS_STORY_NAME } from '../../src/constants';
 import { StoryFnReactReturnType } from '@storybook/react/dist/client/preview/types';
-import { getDirection } from '@pxblue/storybook-rtl-addon';
+import { getLeftToRightIconTransform } from '../../src/utils';
 import { text } from '@storybook/addon-knobs';
 
 export const withBasicUsage = (): StoryFnReactReturnType => (
     <EmptyState
-        icon={
-            <NotListedLocation
-                fontSize={'inherit'}
-                style={{ transform: getDirection() === 'rtl' ? 'scaleX(-1)' : undefined }}
-            />
-        }
+        icon={<NotListedLocation fontSize={'inherit'} style={getLeftToRightIconTransform()} />}
         title={text('title', 'Location Unknown')}
     />
 );

--- a/demos/storybook/stories/empty-state/with-full-config.tsx
+++ b/demos/storybook/stories/empty-state/with-full-config.tsx
@@ -4,7 +4,7 @@ import { EmptyState } from '@pxblue/react-components';
 import { action } from '@storybook/addon-actions';
 import { text } from '@storybook/addon-knobs';
 import { StoryFnReactReturnType } from '@storybook/react/dist/client/preview/types';
-import { getDirection } from '@pxblue/storybook-rtl-addon';
+import { getLeftToRightIconTransform } from '../../src/utils';
 import React from 'react';
 import { WITH_FULL_CONFIG_STORY_NAME } from '../../src/constants';
 
@@ -14,12 +14,7 @@ export const withFullConfig = (): StoryFnReactReturnType => {
     const actionText = text('Action Text', 'Learn More');
     return (
         <EmptyState
-            icon={
-                <TrendingUpIcon
-                    fontSize={'inherit'}
-                    style={{ transform: getDirection() === 'rtl' ? 'scaleX(-1)' : undefined }}
-                />
-            }
+            icon={<TrendingUpIcon fontSize={'inherit'} style={getLeftToRightIconTransform()} />}
             title={title}
             description={description}
             actions={

--- a/demos/storybook/stories/empty-state/with-full-config.tsx
+++ b/demos/storybook/stories/empty-state/with-full-config.tsx
@@ -4,6 +4,7 @@ import { EmptyState } from '@pxblue/react-components';
 import { action } from '@storybook/addon-actions';
 import { text } from '@storybook/addon-knobs';
 import { StoryFnReactReturnType } from '@storybook/react/dist/client/preview/types';
+import { getDirection } from '@pxblue/storybook-rtl-addon';
 import React from 'react';
 import { WITH_FULL_CONFIG_STORY_NAME } from '../../src/constants';
 
@@ -13,7 +14,12 @@ export const withFullConfig = (): StoryFnReactReturnType => {
     const actionText = text('Action Text', 'Learn More');
     return (
         <EmptyState
-            icon={<TrendingUpIcon fontSize={'inherit'} style={{ marginBottom: '0' }} />}
+            icon={
+                <TrendingUpIcon
+                    fontSize={'inherit'}
+                    style={{ transform: getDirection() === 'rtl' ? 'scaleX(-1)' : undefined }}
+                />
+            }
             title={title}
             description={description}
             actions={

--- a/demos/storybook/stories/user-menu/with-basic-usage.tsx
+++ b/demos/storybook/stories/user-menu/with-basic-usage.tsx
@@ -1,12 +1,12 @@
+import React from 'react';
 import { Avatar } from '@material-ui/core';
 import { Email, ExitToApp, Settings } from '@material-ui/icons';
 import { UserMenu, UserMenuItem } from '@pxblue/react-components';
 import { action } from '@storybook/addon-actions';
 import { text } from '@storybook/addon-knobs';
 import { StoryFnReactReturnType } from '@storybook/react/dist/client/preview/types';
-import { getDirection } from '@pxblue/storybook-rtl-addon';
-import React from 'react';
 import { WITH_MIN_PROPS_STORY_NAME } from '../../src/constants';
+import { getLeftToRightIconTransform } from '../../src/utils';
 
 const menuItems: UserMenuItem[] = [
     {
@@ -21,7 +21,7 @@ const menuItems: UserMenuItem[] = [
     },
     {
         title: 'Log Out',
-        icon: <ExitToApp style={{ transform: getDirection() === 'rtl' ? 'scaleX(-1)' : undefined }} />,
+        icon: <ExitToApp style={getLeftToRightIconTransform()} />,
         onClick: action("click 'Log Out'"),
     },
 ];

--- a/demos/storybook/stories/user-menu/with-basic-usage.tsx
+++ b/demos/storybook/stories/user-menu/with-basic-usage.tsx
@@ -4,6 +4,7 @@ import { UserMenu, UserMenuItem } from '@pxblue/react-components';
 import { action } from '@storybook/addon-actions';
 import { text } from '@storybook/addon-knobs';
 import { StoryFnReactReturnType } from '@storybook/react/dist/client/preview/types';
+import { getDirection } from '@pxblue/storybook-rtl-addon';
 import React from 'react';
 import { WITH_MIN_PROPS_STORY_NAME } from '../../src/constants';
 
@@ -20,7 +21,7 @@ const menuItems: UserMenuItem[] = [
     },
     {
         title: 'Log Out',
-        icon: <ExitToApp />,
+        icon: <ExitToApp style={{ transform: getDirection() === 'rtl' ? 'scaleX(-1)' : undefined }} />,
         onClick: action("click 'Log Out'"),
     },
 ];

--- a/demos/storybook/stories/user-menu/within-a-toolbar.tsx
+++ b/demos/storybook/stories/user-menu/within-a-toolbar.tsx
@@ -2,6 +2,7 @@ import { AppBar, Avatar, makeStyles, Toolbar, Typography } from '@material-ui/co
 import { Spacer, UserMenu, UserMenuItem } from '@pxblue/react-components';
 import { action } from '@storybook/addon-actions';
 import { StoryFnReactReturnType } from '@storybook/react/dist/client/preview/types';
+import { getDirection } from '@pxblue/storybook-rtl-addon';
 import React from 'react';
 import * as Colors from '@pxblue/colors';
 import { Email, ExitToApp, Settings } from '@material-ui/icons';
@@ -16,7 +17,7 @@ export const withinToolbar = (): StoryFnReactReturnType => {
         title: {
             color: Colors.gray[600],
             fontSize: 12,
-            textAlign: 'right',
+            textAlign: getDirection() === 'rtl' ? 'left' : 'right',
         },
     });
 
@@ -37,7 +38,7 @@ export const withinToolbar = (): StoryFnReactReturnType => {
             itemID: '3',
             title: 'Log Out',
             divider: true,
-            icon: <ExitToApp />,
+            icon: <ExitToApp style={{ transform: getDirection() === 'rtl' ? 'scaleX(-1)' : undefined }} />,
             onClick: action("click 'Log Out'"),
         },
         {

--- a/demos/storybook/stories/user-menu/within-a-toolbar.tsx
+++ b/demos/storybook/stories/user-menu/within-a-toolbar.tsx
@@ -3,6 +3,7 @@ import { Spacer, UserMenu, UserMenuItem } from '@pxblue/react-components';
 import { action } from '@storybook/addon-actions';
 import { StoryFnReactReturnType } from '@storybook/react/dist/client/preview/types';
 import { getDirection } from '@pxblue/storybook-rtl-addon';
+import { getLeftToRightIconTransform } from '../../src/utils';
 import React from 'react';
 import * as Colors from '@pxblue/colors';
 import { Email, ExitToApp, Settings } from '@material-ui/icons';
@@ -38,7 +39,7 @@ export const withinToolbar = (): StoryFnReactReturnType => {
             itemID: '3',
             title: 'Log Out',
             divider: true,
-            icon: <ExitToApp style={{ transform: getDirection() === 'rtl' ? 'scaleX(-1)' : undefined }} />,
+            icon: <ExitToApp style={getLeftToRightIconTransform()} />,
             onClick: action("click 'Log Out'"),
         },
         {


### PR DESCRIPTION
<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Fix the icons that should not be flipped. Refer to https://github.com/pxblue/react-design-patterns/pull/30

<!-- Include screenshots if they will help illustrate the changes in this PR -->
#### Screenshots:
![image](https://user-images.githubusercontent.com/8997218/92192414-f3d84080-ee33-11ea-80c0-445388bbc288.png)
(only the log out icon is flipped, as it carries some directionality)