### PR TITLE
Update default LIT styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## TBD
+
+### Changed
+-   Updated styles for default `<ListItemTag>`
+
 ## v4.1.1
 
 ### Changed

--- a/components/src/core/ListItemTag/ListItemTag.tsx
+++ b/components/src/core/ListItemTag/ListItemTag.tsx
@@ -21,7 +21,7 @@ const useStyles = makeStyles((theme: Theme) =>
             borderRadius: theme.spacing(0.25),
             padding: 0,
             paddingLeft: theme.spacing(0.5),
-            paddingRight: theme.spacing(0.5),
+            paddingRight: theme.spacing(0.5) - 1, // to account for extra pixel from letter-spacing
             overflow: 'hidden',
             backgroundColor: (props: ListItemTagProps): string => props.backgroundColor || theme.palette.primary.main,
             color: (props: ListItemTagProps): string => props.fontColor || theme.palette.primary.contrastText,
@@ -29,7 +29,7 @@ const useStyles = makeStyles((theme: Theme) =>
             display: 'inline-block',
         },
         noVariant: {
-            fontWeight: 'bold',
+            fontWeight: 700, // bold
             letterSpacing: 1,
             fontSize: 10,
             lineHeight: '16px',

--- a/components/src/core/ListItemTag/ListItemTag.tsx
+++ b/components/src/core/ListItemTag/ListItemTag.tsx
@@ -15,6 +15,18 @@ export type ListItemTagProps = TypographyProps & {
     label: string;
 };
 
+// See https://material-ui.com/guides/right-to-left/#opting-out-of-rtl-transformation
+declare module '@material-ui/core/styles/withStyles' {
+    // Augment the BaseCSSProperties so that we can control jss-rtl
+    // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+    interface BaseCSSProperties {
+        /**
+         * Used to control if the rule-set should be affected by rtl transformation
+         */
+        flip?: boolean;
+    }
+}
+
 const useStyles = makeStyles((theme: Theme) =>
     createStyles({
         root: {
@@ -27,6 +39,7 @@ const useStyles = makeStyles((theme: Theme) =>
             color: (props: ListItemTagProps): string => props.fontColor || theme.palette.primary.contrastText,
             cursor: (props: ListItemTagProps): string => (props.onClick ? 'pointer' : 'inherit'),
             display: 'inline-block',
+            flip: false, // letter-spacing doesn't flip for RTL, so neither shall our padding hack to offset it
         },
         noVariant: {
             fontWeight: 700, // bold

--- a/components/src/core/ListItemTag/ListItemTag.tsx
+++ b/components/src/core/ListItemTag/ListItemTag.tsx
@@ -1,10 +1,10 @@
 import { Typography, TypographyProps } from '@material-ui/core';
-import { createStyles, makeStyles, Theme, TypographyVariant } from '@material-ui/core/styles';
+import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
 import React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
 
-export type ListItemTagProps = {
+export type ListItemTagProps = TypographyProps & {
     /* Color of the label background. Default is theme.palette.primary.main */
     backgroundColor?: string;
 
@@ -13,10 +13,7 @@ export type ListItemTagProps = {
 
     /* The string label of the tag. */
     label: string;
-
-    /* The typography variant - we override this to allow for undefined (default styles). */
-    variant?: TypographyVariant;
-} & Omit<TypographyProps, 'variant'>;
+};
 
 const useStyles = makeStyles((theme: Theme) =>
     createStyles({
@@ -25,17 +22,18 @@ const useStyles = makeStyles((theme: Theme) =>
             padding: 0,
             paddingLeft: theme.spacing(0.5),
             paddingRight: theme.spacing(0.5),
-            lineHeight: 'inherit',
             overflow: 'hidden',
             backgroundColor: (props: ListItemTagProps): string => props.backgroundColor || theme.palette.primary.main,
             color: (props: ListItemTagProps): string => props.fontColor || theme.palette.primary.contrastText,
             cursor: (props: ListItemTagProps): string => (props.onClick ? 'pointer' : 'inherit'),
+            display: 'inline-block',
         },
-        default: {
+        noVariant: {
             fontWeight: 'bold',
             letterSpacing: 1,
             fontSize: 10,
             lineHeight: '16px',
+            height: 16,
         },
     })
 );
@@ -61,11 +59,11 @@ const ListItemTagRender: React.ForwardRefRenderFunction<unknown, ListItemTagProp
         <Typography
             ref={ref}
             classes={{
-                root: clsx(defaultClasses.root, rootUserClass, { [defaultClasses.default]: variant === undefined }),
+                root: clsx(defaultClasses.root, rootUserClass, { [defaultClasses.noVariant]: !variant }),
                 ...otherUserClasses,
             }}
-            data-test={'list-item-tag'}
             variant={variant || 'overline'}
+            data-test={'list-item-tag'}
             {...otherTypographyProps}
         >
             {label}

--- a/components/src/core/ListItemTag/ListItemTag.tsx
+++ b/components/src/core/ListItemTag/ListItemTag.tsx
@@ -1,5 +1,5 @@
 import { Typography, TypographyProps } from '@material-ui/core';
-import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
+import { createStyles, makeStyles, Theme, TypographyVariant } from '@material-ui/core/styles';
 import React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
@@ -13,13 +13,14 @@ export type ListItemTagProps = {
 
     /* The string label of the tag. */
     label: string;
-} & TypographyProps;
+
+    /* The typography variant - we override this to allow for undefined (default styles). */
+    variant?: TypographyVariant;
+} & Omit<TypographyProps, 'variant'>;
 
 const useStyles = makeStyles((theme: Theme) =>
     createStyles({
         root: {
-            fontWeight: 'bold',
-            letterSpacing: 1,
             borderRadius: theme.spacing(0.25),
             padding: 0,
             paddingLeft: theme.spacing(0.5),
@@ -29,6 +30,12 @@ const useStyles = makeStyles((theme: Theme) =>
             backgroundColor: (props: ListItemTagProps): string => props.backgroundColor || theme.palette.primary.main,
             color: (props: ListItemTagProps): string => props.fontColor || theme.palette.primary.contrastText,
             cursor: (props: ListItemTagProps): string => (props.onClick ? 'pointer' : 'inherit'),
+        },
+        default: {
+            fontWeight: 'bold',
+            letterSpacing: 1,
+            fontSize: 10,
+            lineHeight: '16px',
         },
     })
 );
@@ -40,6 +47,7 @@ const ListItemTagRender: React.ForwardRefRenderFunction<unknown, ListItemTagProp
     const {
         classes: userClasses,
         label,
+        variant,
         // ignore unused vars so that we can do prop transferring to the root element
         /* eslint-disable @typescript-eslint/no-unused-vars */
         fontColor,
@@ -52,8 +60,12 @@ const ListItemTagRender: React.ForwardRefRenderFunction<unknown, ListItemTagProp
     return (
         <Typography
             ref={ref}
-            classes={{ root: clsx(defaultClasses.root, rootUserClass), ...otherUserClasses }}
+            classes={{
+                root: clsx(defaultClasses.root, rootUserClass, { [defaultClasses.default]: variant === undefined }),
+                ...otherUserClasses,
+            }}
             data-test={'list-item-tag'}
+            variant={variant || 'overline'}
             {...otherTypographyProps}
         >
             {label}
@@ -70,7 +82,6 @@ ListItemTag.propTypes = {
 };
 ListItemTag.defaultProps = {
     noWrap: true,
-    variant: 'overline',
     display: 'inline',
     classes: {},
 };

--- a/demos/storybook/stories/list-item-tag/with-full-config.tsx
+++ b/demos/storybook/stories/list-item-tag/with-full-config.tsx
@@ -1,7 +1,7 @@
 import * as Colors from '@pxblue/colors';
 import { ListItemTag } from '@pxblue/react-components';
 import { action } from '@storybook/addon-actions';
-import { boolean, color, select, text } from '@storybook/addon-knobs';
+import { boolean, color, text } from '@storybook/addon-knobs';
 import { StoryFnReactReturnType } from '@storybook/react/dist/client/preview/types';
 import React from 'react';
 import { WITH_FULL_CONFIG_STORY_NAME } from '../../src/constants';
@@ -12,27 +12,6 @@ export const withFullConfig = (): StoryFnReactReturnType => (
         backgroundColor={color('backgroundColor', Colors.green[500])}
         fontColor={color('fontColor', Colors.black[900])}
         onClick={action('ListItemTag: onClick')}
-        variant={select(
-            'variant',
-            [
-                'h1',
-                'h2',
-                'h3',
-                'h4',
-                'h5',
-                'h6',
-                'subtitle1',
-                'subtitle2',
-                'body1',
-                'body2',
-                'caption',
-                'button',
-                'overline',
-                'srOnly',
-                'inherit',
-            ],
-            'overline'
-        )}
         style={{
             padding: text('style.padding', '0 4px'),
             width: text('style.width', 'initial'),

--- a/demos/storybook/stories/list-item-tag/within-InfoListItem.tsx
+++ b/demos/storybook/stories/list-item-tag/within-InfoListItem.tsx
@@ -4,26 +4,39 @@ import { StoryFnReactReturnType } from '@storybook/react/dist/client/preview/typ
 import React from 'react';
 import { BrightnessMedium } from '@material-ui/icons';
 import List from '@material-ui/core/List';
+import { getDirection } from '@pxblue/storybook-rtl-addon';
+import { useTheme } from '@material-ui/core';
 
-export const inInfoListItem = (): StoryFnReactReturnType => (
-    <List style={{ width: '80%', background: Colors.white[50], padding: 0 }}>
-        <InfoListItem
-            icon={<BrightnessMedium />}
-            title={'@pxblue/react-themes'}
-            subtitle={'Light and dark themes supported'}
-            rightComponent={
-                <div>
-                    <ListItemTag
-                        label={'Build Passing'}
-                        backgroundColor={Colors.green[300]}
-                        fontColor={Colors.black[900]}
-                        style={{ marginRight: 8 }}
-                    />
-                    <ListItemTag label={'5 Bugs'} backgroundColor={Colors.yellow[500]} fontColor={Colors.black[900]} />
-                </div>
-            }
-        />
-    </List>
-);
+export const inInfoListItem = (): StoryFnReactReturnType => {
+    const direction = getDirection();
+    const theme = useTheme();
+    return (
+        <List style={{ width: '80%', background: Colors.white[50], padding: 0 }}>
+            <InfoListItem
+                icon={<BrightnessMedium />}
+                title={'@pxblue/react-themes'}
+                subtitle={'Light and dark themes supported'}
+                rightComponent={
+                    <div>
+                        <ListItemTag
+                            label={'Build Passing'}
+                            backgroundColor={Colors.green[300]}
+                            fontColor={Colors.black[900]}
+                            style={{
+                                marginRight: direction === 'rtl' ? 0 : theme.spacing(1),
+                                marginLeft: direction === 'rtl' ? theme.spacing(1) : 0,
+                            }}
+                        />
+                        <ListItemTag
+                            label={'5 Bugs'}
+                            backgroundColor={Colors.yellow[500]}
+                            fontColor={Colors.black[900]}
+                        />
+                    </div>
+                }
+            />
+        </List>
+    );
+};
 
 inInfoListItem.story = { name: 'within an Info List Item' };

--- a/demos/storybook/stories/list-item-tag/within-InfoListItem.tsx
+++ b/demos/storybook/stories/list-item-tag/within-InfoListItem.tsx
@@ -12,11 +12,12 @@ export const inInfoListItem = (): StoryFnReactReturnType => (
             title={'@pxblue/react-themes'}
             subtitle={'Light and dark themes supported'}
             rightComponent={
-                <div style={{ width: 180, display: 'flex', justifyContent: 'space-between' }}>
+                <div>
                     <ListItemTag
                         label={'Build Passing'}
                         backgroundColor={Colors.green[300]}
                         fontColor={Colors.black[900]}
+                        style={{ marginRight: 8 }}
                     />
                     <ListItemTag label={'5 Bugs'} backgroundColor={Colors.yellow[500]} fontColor={Colors.black[900]} />
                 </div>

--- a/demos/storybook/stories/list-item-tag/within-InfoListItem.tsx
+++ b/demos/storybook/stories/list-item-tag/within-InfoListItem.tsx
@@ -23,8 +23,8 @@ export const inInfoListItem = (): StoryFnReactReturnType => {
                             backgroundColor={Colors.green[300]}
                             fontColor={Colors.black[900]}
                             style={{
-                                marginRight: direction === 'rtl' ? 0 : theme.spacing(1),
-                                marginLeft: direction === 'rtl' ? theme.spacing(1) : 0,
+                                marginRight: direction === 'rtl' ? 0 : theme.spacing(2),
+                                marginLeft: direction === 'rtl' ? theme.spacing(2) : 0,
                             }}
                         />
                         <ListItemTag

--- a/demos/storybook/stories/list-item-tag/within-InfoListItem.tsx
+++ b/demos/storybook/stories/list-item-tag/within-InfoListItem.tsx
@@ -17,7 +17,7 @@ export const inInfoListItem = (): StoryFnReactReturnType => {
                 title={'@pxblue/react-themes'}
                 subtitle={'Light and dark themes supported'}
                 rightComponent={
-                    <div>
+                    <div style={{ display: 'flex' }}>
                         <ListItemTag
                             label={'Build Passing'}
                             backgroundColor={Colors.green[300]}


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
For PXBLUE-1564 .

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Remove the default Overline typography variant for LIT
- If variant is not specified, default to our recommended styles
- If variant is specified, use those styles (plus some for padding and roundness)

The end result should look almost exactly the same unless a user has been setting an explicit variant.

<!-- Include screenshots if they will help illustrate the changes in this PR -->
#### Screenshots:
![image](https://user-images.githubusercontent.com/29152776/96626705-d5dc7780-12dd-11eb-8ab7-243af93aa84a.png)
