### PR TITLE
Hero margin 5px -> 8px

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,11 @@
 ## TBD
 
 ### Changed
--   Updated styles for default `<ListItemTag>`
+
+-   Updated styles for default `<ListItemTag>` and `<Hero>`
 
 ### Added
+
 -   Adds `hidden` prop to the Drawer `NavItem` to conditionally omit items from the `<Drawer>` or `<UserMenu>`.
 
 ## v4.1.1

--- a/components/src/core/Hero/Hero.tsx
+++ b/components/src/core/Hero/Hero.tsx
@@ -46,7 +46,7 @@ const useStyles = makeStyles((theme: Theme) =>
         icon: {
             lineHeight: 1,
             color: theme.palette.text.secondary,
-            marginBottom: 5,
+            marginBottom: theme.spacing(0.5),
             display: 'flex',
             alignItems: 'center',
             justifyContent: 'center',

--- a/components/src/core/Hero/Hero.tsx
+++ b/components/src/core/Hero/Hero.tsx
@@ -46,7 +46,7 @@ const useStyles = makeStyles((theme: Theme) =>
         icon: {
             lineHeight: 1,
             color: theme.palette.text.secondary,
-            marginBottom: theme.spacing(0.5),
+            marginBottom: theme.spacing(),
             display: 'flex',
             alignItems: 'center',
             justifyContent: 'center',


### PR DESCRIPTION
<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
## Changes proposed in this Pull Request:
- Replaced a magic number to use `theme.spacing(1)` to match design files

<!-- Include screenshots if they will help illustrate the changes in this PR -->
## Screenshots
| Present (9px) | Proposed (12px) |
| -- | -- |
|![image](https://user-images.githubusercontent.com/8997218/100691475-ca598300-3356-11eb-945e-f00e022ad7fb.png) | ![image](https://user-images.githubusercontent.com/8997218/100691459-c299de80-3356-11eb-956e-3dc918c32951.png) |

_I know... this is just some designer itch_

## Additional Comment

I was looking into RN too, but it seems that RN is using some different pixels / dimensions than ng / React, so I didn't touch RNCL.