### PR TITLE
Use darkBlack[500] for nest nav item bg color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 4.2.1 (not published)
+
+### Fixed
+
+-   `<Drawer>` nested nav item dark-themed background color. 
+
 ## 4.2.0
 
 ### Changed

--- a/components/package.json
+++ b/components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@pxblue/react-components",
-    "version": "4.2.0",
+    "version": "4.2.1",
     "description": "React components for PX Blue applications",
     "scripts": {
         "test": "jest src",

--- a/components/src/core/Drawer/DrawerNavItem.tsx
+++ b/components/src/core/Drawer/DrawerNavItem.tsx
@@ -8,6 +8,7 @@ import { PXBlueDrawerInheritableProperties } from './Drawer';
 import { DrawerNavGroupProps } from './DrawerNavGroup';
 import { InfoListItem } from '../InfoListItem';
 import { useDrawerContext } from './DrawerContext';
+import * as Colors from '@pxblue/colors';
 
 export type NavItem = {
     // sets whether to hide the nav item
@@ -264,7 +265,7 @@ const DrawerNavItemRender: React.ForwardRefRenderFunction<unknown, DrawerNavItem
                                 </div>
                             )
                         }
-                        backgroundColor={'transparent'}
+                        backgroundColor={theme.palette.type === 'light' ? 'transparent' : Colors.darkBlack[500]}
                         onClick={hasAction ? onClickAction : undefined}
                         hidePadding={hidePadding}
                         ripple={ripple}


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes #196 

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Use darkBlack[500] for dark-themed nest nav item bg color


