### PR TITLE
Use favorite icon in scorecard sb story

### DIFF
--- a/demos/storybook/stories/score-card/with-actions.tsx
+++ b/demos/storybook/stories/score-card/with-actions.tsx
@@ -1,5 +1,5 @@
 import { List, ListItem, ListItemText } from '@material-ui/core';
-import { Cloud, ListAlt, Mail, MoreVert, Notifications, Search } from '@material-ui/icons';
+import { Cloud, Favorite, Mail, MoreVert, Notifications, Search } from '@material-ui/icons';
 import * as Colors from '@pxblue/colors';
 import { ScoreCard, InfoListItem } from '@pxblue/react-components';
 import { action } from '@storybook/addon-actions';
@@ -19,7 +19,7 @@ export const actionItems = [
     <Search onClick={action('clicked search')} key={'search'} />,
     <Mail onClick={action('clicked mail')} key={'mail'} />,
     <Notifications onClick={action('clicked alarms')} key={'notifications'} />,
-    <ListAlt onClick={action('clicked list')} key={'listalt'} />,
+    <Favorite onClick={action('clicked favorite')} key={'favorite'} />,
     <Cloud onClick={action('clicked cloud')} key={'cloud'} />,
     <MoreVert onClick={action('clicked more')} key={'morevert'} />,
 ];


### PR DESCRIPTION
<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Remove ListAlt icon since it's RTL-sensitive.  Replace with Favorite icon.

![image](https://user-images.githubusercontent.com/6538289/105866401-f34a6d00-5fc1-11eb-8cc3-0563793d5609.png)
