### PR TITLE
Update ILI text styles for dark theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changed
 
--   Some default colors in `<Drawer>` and `<ScoreCard>` headers to work with @pxblue/react-themes version 6+.
+-   Some default colors in `<InfoListItem>`, `<Drawer>` and `<ScoreCard>` headers to work with @pxblue/react-themes version 6+.
 
 ## 5.0.0
 
@@ -17,6 +17,7 @@
 -   Some of the class names for style overrides have changed
 
 ### Added
+
 -   Additional configuration properties for `<Drawer>`:
     -   `sideBorder` gives the `<Drawer>` a slight border instead of a drop shadow.
     -   `disableActiveItemParentStyle` disables the bold text style for active item's parent elements.
@@ -65,10 +66,12 @@
 
 ## v4.0.2
 
-### Added 
+### Added
+
 -   Adds `info` prop to `<InfoListItem>` to support a third line of text.
 
 ### Changed
+
 -   Updates several prop types to `ReactNode` to support wider range of input values.
 
 ## v4.0.1
@@ -77,10 +80,12 @@
 
 ## v4.0.0
 
-### Added  
+### Added
+
 -   Style-related properties are now overridable by the `classes` prop in each component.
 
 ### Changed
+
 -   Supplemental properties are now spread to the root component for each PX Blue component.
 -   Changed component font colors to address potential accessibility issues.
 
@@ -91,16 +96,19 @@
 ## v3.0.3
 
 ### Fixed
+
 -   Fixes IE 11 issue where persistent `<Drawer>` will not close.
 -   Fixes some spacing issues when using the `<DrawerLayout>`.
 
 ## v3.0.0
 
-### Added 
+### Added
+
 -   Adds support for nested items in the `<Drawer>` component.
 -   Additional styling props added to `<Drawer>`.
 
-### Changed 
+### Changed
+
 **Breaking Changes:**
 
 -   A few props got renamed to avoid further ambiguities:
@@ -143,18 +151,21 @@
 
 ## v2.1.0
 
-### Added 
+### Added
+
 -   Adds `<InfoListTag>` Component
     -   Displays additional information inside an InfoListItem.
 -   Adds `<UserMenu>` Component
     -   Avatar which opens a Menu when clicked.
-    
-### Fixed 
+
+### Fixed
+
 -   Misc bug fixes.
 
 ## v2.0.0
 
 ### Added
+
 -   Adds new components for:
     -   `<Drawer>`
     -   `<DrawerHeader>`
@@ -165,6 +176,7 @@
     -   `<DrawerLayout>`
 
 ### Changed
+
 -   Library converted to TypeScript to provide strong typings for TS projects.
 -   **Breaking Change:** Simpler import syntax - _default_ imports will no longer work.
 
@@ -178,12 +190,14 @@
 
 ## v1.1.0
 
-### Added 
+### Added
+
 Adds a new component for `<EmptyState>`.
 
 ## v1.0.0
 
-### Fixed 
+### Fixed
+
 Fixes a bug in icon size for inline `<ChannelValue>` components.
 
 ## v0.0.1

--- a/components/src/core/Drawer/DrawerNavItem.tsx
+++ b/components/src/core/Drawer/DrawerNavItem.tsx
@@ -117,6 +117,9 @@ const useStyles = makeStyles((theme: Theme) =>
                 (props.depth > 0 ? props.nestedBackgroundColor : props.backgroundColor) || 'transparent',
         },
         square: {},
+        textSecondary: {
+            color: theme.palette.type === 'dark' ? theme.palette.text.secondary : undefined,
+        },
         title: {
             fontWeight: 400,
         },
@@ -367,10 +370,11 @@ const DrawerNavItemRender: React.ForwardRefRenderFunction<HTMLElement, DrawerNav
             [defaultClasses.noIconTitle]: hidePadding && !icon,
             [defaultClasses.drawerOpen]: drawerOpen,
         }),
-        subtitle: clsx({
+        subtitle: clsx(defaultClasses.textSecondary, {
             [defaultClasses.noIconTitle]: hidePadding && !icon,
             [defaultClasses.drawerOpen]: drawerOpen,
         }),
+        info: defaultClasses.textSecondary,
     };
 
     return (

--- a/components/src/core/InfoListItem/InfoListItem.styles.tsx
+++ b/components/src/core/InfoListItem/InfoListItem.styles.tsx
@@ -18,13 +18,13 @@ export type InfoListItemClasses = {
 };
 
 const getHeight = (props: InfoListItemProps): number => (props.dense ? 52 : 72);
-const getIconColor = (props: InfoListItemProps): string => {
+const getIconColor = (props: InfoListItemProps, theme: Theme): string => {
     const { avatar, iconColor, statusColor } = props;
     if (iconColor) return iconColor;
     if (avatar) {
         return statusColor ? (color(statusColor).isDark() ? Colors.white[50] : Colors.black[500]) : Colors.white[50]; // default avatar is dark gray -> white text
     }
-    return statusColor ? statusColor : 'inherit';
+    return statusColor ? statusColor : theme.palette.type === 'dark' ? theme.palette.text.secondary : 'inherit';
 };
 
 const isWrapEnabled = (props: InfoListItemProps): boolean => props.wrapSubtitle || props.wrapTitle;
@@ -67,7 +67,7 @@ export const useStyles = makeStyles<Theme, InfoListItemProps>((theme: Theme) =>
         },
         avatar: {
             backgroundColor: (props) => props.statusColor || Colors.black[500],
-            color: (props) => getIconColor(props),
+            color: (props) => getIconColor(props, theme),
         },
         divider: {
             position: 'absolute',
@@ -80,7 +80,7 @@ export const useStyles = makeStyles<Theme, InfoListItemProps>((theme: Theme) =>
             marginLeft: (props) => (props.leftComponent ? theme.spacing(2) : 0),
         },
         icon: {
-            color: (props) => getIconColor(props),
+            color: (props) => getIconColor(props, theme),
             justifyContent: (props) => getIconAlignment(props),
             backgroundColor: 'transparent',
             overflow: 'visible',
@@ -88,7 +88,8 @@ export const useStyles = makeStyles<Theme, InfoListItemProps>((theme: Theme) =>
         info: {
             fontWeight: 400,
             lineHeight: 1.3,
-            color: (props) => props.fontColor || 'inherit',
+            color: (props) =>
+                props.fontColor || (theme.palette.type === 'dark' ? theme.palette.text.secondary : 'inherit'),
         },
         rightComponent: {
             flex: '0 0 auto',
@@ -114,7 +115,8 @@ export const useStyles = makeStyles<Theme, InfoListItemProps>((theme: Theme) =>
         subtitle: {
             fontWeight: 400,
             lineHeight: 1.3,
-            color: (props) => props.fontColor || 'inherit',
+            color: (props) =>
+                props.fontColor || (theme.palette.type === 'dark' ? theme.palette.text.secondary : 'inherit'),
         },
         title: {
             fontWeight: 600,

--- a/components/src/core/InfoListItem/InfoListItem.tsx
+++ b/components/src/core/InfoListItem/InfoListItem.tsx
@@ -225,7 +225,6 @@ InfoListItem.defaultProps = {
     chevron: false,
     classes: {},
     dense: false,
-    fontColor: 'inherit',
     hidePadding: false,
     iconAlign: 'left',
     ripple: false,


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
From comment on https://github.com/pxblue/themes/pull/135

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Update the subtitle, info, and icon color for ILI in dark theme
- DrawerNavItem still uses black[50] for the icon

<!-- Include screenshots if they will help illustrate the changes in this PR -->
#### Screenshots:
![image](https://user-images.githubusercontent.com/29152776/109188749-3afb1a80-7761-11eb-954e-b4f246dc7686.png)
