### PR TITLE
Clean up default colors for LIT in dark theme

### DIFF
--- a/components/package.json
+++ b/components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@pxblue/react-components",
-    "version": "5.0.1",
+    "version": "5.0.1-beta.0",
     "description": "React components for PX Blue applications",
     "scripts": {
         "test": "jest src",

--- a/components/src/core/ListItemTag/ListItemTag.tsx
+++ b/components/src/core/ListItemTag/ListItemTag.tsx
@@ -35,8 +35,15 @@ const useStyles = makeStyles((theme: Theme) =>
             paddingLeft: theme.spacing(0.5),
             paddingRight: theme.spacing(0.5) - 1, // to account for extra pixel from letter-spacing
             overflow: 'hidden',
-            backgroundColor: (props: ListItemTagProps): string => props.backgroundColor || theme.palette.primary.main,
-            color: (props: ListItemTagProps): string => props.fontColor || theme.palette.primary.contrastText,
+            backgroundColor: (props: ListItemTagProps): string =>
+                props.backgroundColor ||
+                (theme.palette.type === 'dark' ? theme.palette.primary.dark : theme.palette.primary.main),
+            color: (props: ListItemTagProps): string =>
+                props.fontColor ||
+                theme.palette.getContrastText(
+                    props.backgroundColor ||
+                        (theme.palette.type === 'dark' ? theme.palette.primary.dark : theme.palette.primary.main)
+                ),
             cursor: (props: ListItemTagProps): string => (props.onClick ? 'pointer' : 'inherit'),
             display: 'inline-block',
             flip: false, // letter-spacing doesn't flip for RTL, so neither shall our padding hack to offset it

--- a/docs/ListItemTag.md
+++ b/docs/ListItemTag.md
@@ -19,8 +19,8 @@ import { ListItemTag } from '@pxblue/react-components';
 | Prop Name       | Description                   | Type     | Required | Default                              |
 | --------------- | ----------------------------- | -------- | -------- | ------------------------------------ |
 | label           | The label text                | `string` | yes      |                                      |
-| fontColor       | Color of the label            | `string` | no       | `theme.palette.primary.contrastText` |
-| backgroundColor | Color of the label background | `string` | no       | `theme.palette.primary.main`         |
+| fontColor       | Color of the label            | `string` | no       | varies for light/dark theme          |
+| backgroundColor | Color of the label background | `string` | no       | varies for light/dark theme          |
 
 </div>
 


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Use the 500 colors for the default ILI colors in dark mode