### PR TITLE
Add defaultClasses and classes to dropdown appbar's nav icon hook

### DIFF
--- a/components/src/core/DropdownToolbar/DropdownToolbar.tsx
+++ b/components/src/core/DropdownToolbar/DropdownToolbar.tsx
@@ -124,11 +124,12 @@ const DropdownToolbarRender: React.ForwardRefRenderFunction<unknown, DropdownToo
     const theme = useTheme();
     const rtl = theme.direction === 'rtl';
     const defaultClasses = useStyles(theme);
+
     const getNavigationIcon = useCallback(() => {
         if (navigationIcon) {
             return <div className={clsx(defaultClasses.navigation, classes.navigation)}>{navigationIcon}</div>;
         }
-    }, [navigationIcon]);
+    }, [navigationIcon, defaultClasses, classes]);
 
     const closeMenu = useCallback(() => {
         if (onClose) {


### PR DESCRIPTION
I think this might fix an issue I am having when switching between dark theme and light theme... not sure why this does not get triggered in the storybook demo. I guess storybook would re-render every single thing upon a theme change?

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Added defaultClasses and classes to the hook that renders the nav icon

<!-- Include screenshots if they will help illustrate the changes in this PR -->
#### Screenshots:
The thing I am developing right now on docit... every time I switch from one theme to another, it broke like this
![image](https://user-images.githubusercontent.com/8997218/111394238-ba10ae00-8690-11eb-9ece-bc938a84376a.png)
