### PR TITLE
Clean up some styles in storybook

### DIFF
--- a/components/src/core/InfoListItem/InfoListItem.styles.tsx
+++ b/components/src/core/InfoListItem/InfoListItem.styles.tsx
@@ -84,7 +84,9 @@ export const useStyles = makeStyles<Theme, InfoListItemProps>((theme: Theme) =>
             zIndex: 0,
         },
         listItemText: {
-            marginLeft: (props) => (props.leftComponent ? theme.spacing(2) : 0),
+            // we have to specify both here because the auto-swap from JSS isn't smart enough to do it when we use a function
+            marginLeft: (props) => (props.leftComponent ? (theme.direction === 'rtl' ? 0 : theme.spacing(2)) : 0),
+            marginRight: (props) => (props.leftComponent ? (theme.direction === 'rtl' ? theme.spacing(2) : 0) : 0),
         },
         icon: {
             color: (props) => getIconColor(props, theme),

--- a/demos/storybook/package.json
+++ b/demos/storybook/package.json
@@ -9,7 +9,7 @@
         "@pxblue/colors": "^3.0.0",
         "@pxblue/icons-mui": "^2.1.0",
         "@pxblue/react-components": "^4.0.0",
-        "@pxblue/react-themes": "^6.0.0-beta.0",
+        "@pxblue/react-themes": "^6.0.0-beta.2",
         "@pxblue/storybook-rtl-addon": "^1.0.0-alpha.1",
         "@pxblue/storybook-themes": "^1.1.0",
         "@sambego/storybook-state": "^1.3.6",

--- a/demos/storybook/stories/drawer/with-subheader.tsx
+++ b/demos/storybook/stories/drawer/with-subheader.tsx
@@ -26,7 +26,7 @@ const filter = (
         InputProps={{
             endAdornment: (
                 <InputAdornment position="end">
-                    <IconButton aria-label="filter button">
+                    <IconButton aria-label="filter button" edge={'end'}>
                         <Search />
                     </IconButton>
                 </InputAdornment>
@@ -69,7 +69,7 @@ export const withSubheader = (context: DrawerStoryContext): StoryFnReactReturnTy
                     style={{
                         display: 'flex',
                         justifyContent: 'center',
-                        padding: '20px',
+                        padding: '1rem 16px',
                     }}
                 >
                     {subheaderContent === 'Filter' ? filter : accordion}

--- a/demos/storybook/stories/info-list-item/within-full-list.tsx
+++ b/demos/storybook/stories/info-list-item/within-full-list.tsx
@@ -41,7 +41,7 @@ export const withinFullList = (): StoryFnReactReturnType => {
                 title={'Output Voltage'}
                 divider={appliedDivider}
                 avatar
-                statusColor={alertColor}
+                statusColor={Colors.red[500]}
                 fontColor={alertColor}
                 iconColor={Colors.white[50]}
                 subtitle={['Phase A', 'Phase B', 'Phase C']}

--- a/demos/storybook/stories/list-item-tag/within-InfoListItem.tsx
+++ b/demos/storybook/stories/list-item-tag/within-InfoListItem.tsx
@@ -4,18 +4,21 @@ import { StoryFnReactReturnType } from '@storybook/react/dist/client/preview/typ
 import React from 'react';
 import { BrightnessMedium } from '@material-ui/icons';
 import List from '@material-ui/core/List';
+import { useDarkMode } from 'storybook-dark-mode';
 import { getDirection } from '@pxblue/storybook-rtl-addon';
 import { useTheme } from '@material-ui/core';
 
 export const inInfoListItem = (): StoryFnReactReturnType => {
     const direction = getDirection();
     const theme = useTheme();
+
     return (
-        <List style={{ width: '80%', background: theme.palette.background.paper, padding: 0 }}>
+        <List style={{ width: '80%', padding: 0 }}>
             <InfoListItem
                 icon={<BrightnessMedium />}
                 title={'@pxblue/react-themes'}
                 subtitle={'Light and dark themes supported'}
+                backgroundColor={useDarkMode() ? Colors.black[500] : 'white'}
                 rightComponent={
                     <div style={{ display: 'flex' }}>
                         <ListItemTag

--- a/demos/storybook/stories/list-item-tag/within-InfoListItem.tsx
+++ b/demos/storybook/stories/list-item-tag/within-InfoListItem.tsx
@@ -18,7 +18,7 @@ export const inInfoListItem = (): StoryFnReactReturnType => {
                 icon={<BrightnessMedium />}
                 title={'@pxblue/react-themes'}
                 subtitle={'Light and dark themes supported'}
-                backgroundColor={useDarkMode() ? Colors.black[500] : 'white'}
+                backgroundColor={useDarkMode() ? Colors.black[900] : 'white'}
                 rightComponent={
                     <div style={{ display: 'flex' }}>
                         <ListItemTag

--- a/demos/storybook/stories/welcome.stories.tsx
+++ b/demos/storybook/stories/welcome.stories.tsx
@@ -54,7 +54,6 @@ const useStyles = makeStyles(() =>
         githubIcon: {
             width: 24,
             height: 24,
-            marginRight: 8,
             fill: Colors.white[50],
         },
         github: {
@@ -102,12 +101,14 @@ stories.add('PX Blue React Components', () => {
                         className={classes.link}
                         target={'_blank'}
                         href={'https://github.com/pxblue/react-component-library'}
+                        startIcon={
+                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" className={classes.githubIcon}>
+                                <title>github</title>
+                                <rect width="24" height="24" fill="none" />
+                                <path d="M12,2A10,10,0,0,0,8.84,21.5c.5.08.66-.23.66-.5V19.31C6.73,19.91,6.14,18,6.14,18A2.69,2.69,0,0,0,5,16.5c-.91-.62.07-.6.07-.6a2.1,2.1,0,0,1,1.53,1,2.15,2.15,0,0,0,2.91.83,2.16,2.16,0,0,1,.63-1.34C8,16.17,5.62,15.31,5.62,11.5a3.87,3.87,0,0,1,1-2.71,3.58,3.58,0,0,1,.1-2.64s.84-.27,2.75,1a9.63,9.63,0,0,1,5,0c1.91-1.29,2.75-1,2.75-1a3.58,3.58,0,0,1,.1,2.64,3.87,3.87,0,0,1,1,2.71c0,3.82-2.34,4.66-4.57,4.91a2.39,2.39,0,0,1,.69,1.85V21c0,.27.16.59.67.5A10,10,0,0,0,12,2Z" />
+                            </svg>
+                        }
                     >
-                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" className={classes.githubIcon}>
-                            <title>github</title>
-                            <rect width="24" height="24" fill="none" />
-                            <path d="M12,2A10,10,0,0,0,8.84,21.5c.5.08.66-.23.66-.5V19.31C6.73,19.91,6.14,18,6.14,18A2.69,2.69,0,0,0,5,16.5c-.91-.62.07-.6.07-.6a2.1,2.1,0,0,1,1.53,1,2.15,2.15,0,0,0,2.91.83,2.16,2.16,0,0,1,.63-1.34C8,16.17,5.62,15.31,5.62,11.5a3.87,3.87,0,0,1,1-2.71,3.58,3.58,0,0,1,.1-2.64s.84-.27,2.75,1a9.63,9.63,0,0,1,5,0c1.91-1.29,2.75-1,2.75-1a3.58,3.58,0,0,1,.1,2.64,3.87,3.87,0,0,1,1,2.71c0,3.82-2.34,4.66-4.57,4.91a2.39,2.39,0,0,1,.69,1.85V21c0,.27.16.59.67.5A10,10,0,0,0,12,2Z" />
-                        </svg>
                         <Typography variant={'subtitle2'} className={classes.github}>
                             Github
                         </Typography>

--- a/demos/storybook/yarn.lock
+++ b/demos/storybook/yarn.lock
@@ -1649,13 +1649,14 @@
     "@pxblue/colors" "^3.0.0"
     color "^3.1.2"
 
-"@pxblue/react-themes@^6.0.0-beta.0":
-  version "6.0.0-beta.0"
-  resolved "https://registry.yarnpkg.com/@pxblue/react-themes/-/react-themes-6.0.0-beta.0.tgz#885e861769c9ffebef87fae0546d0bacddaadfe6"
-  integrity sha512-dTYJnt6YJbWgo253sqcpz0sGjyy0+NSEEili45dscszb9iq+9zWpQUtSXIGrLQHHRexJoGxuuiQ7F8Wa22G7Rg==
+"@pxblue/react-themes@^6.0.0-beta.2":
+  version "6.0.0-beta.2"
+  resolved "https://registry.yarnpkg.com/@pxblue/react-themes/-/react-themes-6.0.0-beta.2.tgz#38926da93816bc503e2df73d4084dc192fe0f2cb"
+  integrity sha512-VcVrbWMq/78TtmjOTQI0pE6tpP02gIOGLURzdB4YxmENgWtRS1QH9xNFRxr3YBFQxDaqRMWP1P0Le1vysYjRdA==
   dependencies:
     "@fontsource/open-sans" "^4.1.0"
     "@pxblue/colors" "^3.0.0"
+    color "^3.1.3"
 
 "@pxblue/storybook-rtl-addon@^1.0.0-alpha.1":
   version "1.0.0"
@@ -4582,7 +4583,7 @@ color-string@^1.5.4:
     color-name "^1.0.0"
     simple-swizzle "^0.2.2"
 
-color@^3.0.0, color@^3.1.2:
+color@^3.0.0, color@^3.1.2, color@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/color/-/color-3.1.3.tgz#ca67fb4e7b97d611dcde39eceed422067d91596e"
   integrity sha512-xgXAcTHa2HeFCGLE9Xs/R82hujGtu9Jd9x4NW3T34+OMs7VoPsjwzRczKHvTAHeJwWFwX5j15+MgAppE8ztObQ==


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes #260 

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Update some spacing and colors and icon usage

### FUN FACT
Inside the storybook stories, we don't actually have access to the currently applied PXB theme from the useTheme hook. This always returns the default Material UI theme for some reason. I think it's probably some sort of scoping issue with where the stories are created, but it means we can't use any of our theme colors directly in the story. The _components_ that we render pick up the theme correctly, which is why their default colors are correct. Very weird.
