### PR TITLE
Fix misaligned DrawerHeader menu icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 5.1.1
+
+### Fixed
+
+-   Fixed misaligned menu icon in `<DrawerHeader>`.
+
 ## 5.1.0
 
 ### Changed

--- a/components/package.json
+++ b/components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@pxblue/react-components",
-    "version": "5.1.0",
+    "version": "5.1.1",
     "description": "React components for PX Blue applications",
     "scripts": {
         "test": "jest src",

--- a/components/src/core/Drawer/DrawerHeader.tsx
+++ b/components/src/core/Drawer/DrawerHeader.tsx
@@ -45,7 +45,7 @@ const useStyles = makeStyles((theme: Theme) =>
             paddingRight: 0,
             paddingLeft: 0,
             width: '100%',
-            alignItems: 'flex-start',
+            alignItems: 'center',
             boxSizing: 'border-box',
             minHeight: `4rem`,
             [theme.breakpoints.down('xs')]: {


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes #270 

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
Fix misaligned DrawerHeader menu icon

https://pxblue-react-library.web.app/?path=/story/components-drawer--with-basic-config
