### PR TITLE
Fix dependency array for collapse

### DIFF
--- a/components/src/core/AppBar/AppBar.tsx
+++ b/components/src/core/AppBar/AppBar.tsx
@@ -176,7 +176,7 @@ const AppBarRender: React.ForwardRefRenderFunction<unknown, AppBarProps> = (prop
                 (scrollElement || window).scrollTo(0, 1);
             }
         }, animationDuration + 50);
-    }, [collapsedHeight, animationDuration]);
+    }, [collapsedHeight, animationDuration, scrollTop, scrollElement]);
 
     // Smoothly expand the toolbar to the expandedHeight
     const expandToolbar = useCallback(() => {


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes the issue where the page always scrolls to 0,0 when the toolbar collapses, even if the user has scrolled past that point.

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Adds the missing dependencies to callback