### PR TITLE
User menu avatar on click overrides open behavior bug fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 5.3.1 (unreleased)
+## 5.3.1 (August 6, 2021)
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 5.3.1 (unreleased)
+
+### Fixed
+
+-   Issue where `<UserMenu>` Avatar `onClick` prop overrides the open behavior ([#307](https://github.com/pxblue/react-component-library/issues/307)).
+
 ## 5.3.0 (June 30, 2021)
 
 ### Added

--- a/components/src/core/UserMenu/UserMenu.tsx
+++ b/components/src/core/UserMenu/UserMenu.tsx
@@ -136,8 +136,8 @@ const UserMenuRender: React.ForwardRefRenderFunction<unknown, UserMenuProps> = (
             const aProps = avatar.props || {};
 
             return React.cloneElement(avatar, {
-                onClick: preserveOnClick ? onClickFn : undefined,
                 ...aProps,
+                onClick: preserveOnClick ? onClickFn : undefined,
                 classes: {
                     ...aProps.classes,
                     root: clsx(


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes #307 .

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Fix issue where `<UserMenu>` Avatar `onClick` prop overrides the open behavior

<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->
#### To Test:
- Add a UserMenu to a project
- Add an onClick prop to the Avatar, e.g., <Avatar onClick={() => console.log('clicked')}>AB</Avatar>
- Click the avatar
- Observe that the menu is opened and the user-supplied click callback is executed
